### PR TITLE
feat(doughnut): make doughnut center labels customizable

### DIFF
--- a/src/common/plugins/doughnutLabel.js
+++ b/src/common/plugins/doughnutLabel.js
@@ -22,12 +22,33 @@ export default {
       ctx.fillStyle = TextColor;
 
       //Draw text in center
-      ctx.fillText(total, centerX, centerY);
-      ctx.fillText(
-        chart.config.options.scales.y.title.text,
-        centerX,
-        centerY + 20
-      );
+      // get custom options for center text
+      const Line1textOption = chart.config.options.doughnutLabel?.line1text;
+      const Line2textOption = chart.config.options.doughnutLabel?.line2text;
+      let Line1text = total;
+      let Line2text = chart.config.options.scales.y.title.text;
+
+      if (Line1textOption || Line1textOption === '') {
+        Line1text =
+          typeof Line1textOption === 'function'
+            ? Line1textOption(Line1text, ctx)
+            : Line1textOption;
+      }
+
+      if (Line2textOption || Line2textOption === '') {
+        Line2text =
+          typeof Line2textOption === 'function'
+            ? Line2textOption(Line2text, ctx)
+            : Line2textOption;
+      }
+      // const Line1text =
+      //   chart.config.options.doughnutLabel?.line1text(ctx) || total;
+      // const Line2text =
+      //   chart.config.options.doughnutLabel?.line2text ||
+      //   chart.config.options.scales.y.title.text;
+
+      ctx.fillText(Line1text, centerX, centerY);
+      ctx.fillText(Line2text, centerX, centerY + 20);
     }
   },
 };

--- a/src/common/plugins/doughnutLabel.js
+++ b/src/common/plugins/doughnutLabel.js
@@ -25,9 +25,12 @@ export default {
       // get custom options for center text
       const Line1textOption = chart.config.options.doughnutLabel?.line1text;
       const Line2textOption = chart.config.options.doughnutLabel?.line2text;
+
+      // set default values
       let Line1text = total;
       let Line2text = chart.config.options.scales.y.title.text;
 
+      // determine if line1text option is given, is a function or not, and update text
       if (Line1textOption || Line1textOption === '') {
         Line1text =
           typeof Line1textOption === 'function'
@@ -35,17 +38,13 @@ export default {
             : Line1textOption;
       }
 
+      // determine if line2text option is given, is a function or not, and update text
       if (Line2textOption || Line2textOption === '') {
         Line2text =
           typeof Line2textOption === 'function'
             ? Line2textOption(Line2text, ctx)
             : Line2textOption;
       }
-      // const Line1text =
-      //   chart.config.options.doughnutLabel?.line1text(ctx) || total;
-      // const Line2text =
-      //   chart.config.options.doughnutLabel?.line2text ||
-      //   chart.config.options.scales.y.title.text;
 
       ctx.fillText(Line1text, centerX, centerY);
       ctx.fillText(Line2text, centerX, centerY + 20);

--- a/src/common/plugins/doughnutLabel.js
+++ b/src/common/plugins/doughnutLabel.js
@@ -6,7 +6,10 @@ const TextColor =
 export default {
   id: 'doughnutLabel',
   beforeDraw: (chart, args, options) => {
-    if (chart.config.type === 'doughnut') {
+    if (
+      chart.config.type === 'doughnut' &&
+      !chart.config.options.doughnutLabel?.disabled
+    ) {
       const { ctx } = chart;
 
       // get sum of all visible data points

--- a/src/stories/DoughnutLabel.mdx
+++ b/src/stories/DoughnutLabel.mdx
@@ -1,0 +1,55 @@
+import { Meta, Story, Canvas, Controls, Stories } from '@storybook/blocks';
+import * as PieDoughnutStories from './PieDoughnut.stories.js';
+
+<Meta title="Charts/Pie & Doughnut/Doughnut Label" />
+
+# Doughnut Labels Plugin
+
+Customize or disable the labels in the center of the doughnut chart.
+
+## Configuration
+
+Pass `doughtnutLabel` configuration to the chart `options`.
+
+### Defaults
+
+```js
+{
+  doughnutLabel: {
+    disabled: false, // boolean
+    line1text: total, // string or function
+    line2text: options.scales.y.title.text, // string or function
+  }
+}
+```
+
+### Custom Strings
+
+```js
+{
+  doughnutLabel: {
+    line1text: 'Line 1';
+  }
+}
+```
+
+### Scriptable Functions
+
+A custom function that returns a string. The first prop is the default value. The second prop is the chart instance/context.
+
+```js
+{
+  doughnutLabel: {
+    line1text: function (defaultValue, context) {
+      // example: add commas to total
+      return defaultValue.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+  }
+}
+```
+
+## Example
+
+<Canvas of={PieDoughnutStories.DoughnutCustomCenterLabel}>
+  <Story of={PieDoughnutStories.DoughnutCustomCenterLabel} />
+</Canvas>

--- a/src/stories/Geo.stories.js
+++ b/src/stories/Geo.stories.js
@@ -51,7 +51,10 @@ export const WorldChoropleth = {
     datasets: [
       {
         label: 'Countries',
-        data: countries.map((d) => ({ feature: d, value: Math.random() * 10 })),
+        data: countries.map((d) => ({
+          feature: d,
+          value: d.properties.name.length * 10,
+        })),
       },
     ],
   },
@@ -84,7 +87,10 @@ export const CountryChoropleth = {
       {
         label: 'States',
         outline: nation,
-        data: states.map((d) => ({ feature: d, value: Math.random() * 10 })),
+        data: states.map((d) => ({
+          feature: d,
+          value: d.properties.name.length * 10,
+        })),
       },
     ],
     options: {
@@ -126,7 +132,7 @@ export const WorldBubbleMap = {
         outline: countries,
         label: 'Countries',
         data: nationCapitals.map((d) =>
-          Object.assign(d, { value: Math.round(Math.random() * 100) })
+          Object.assign(d, { value: d.description.length * 100 })
         ),
       },
     ],
@@ -161,7 +167,7 @@ export const CountryBubbleMap = {
       {
         outline: states,
         data: capitals.map((d) =>
-          Object.assign(d, { value: Math.round(Math.random() * 100) })
+          Object.assign(d, { value: d.description.length * 100 })
         ),
       },
     ],

--- a/src/stories/PieDoughnut.stories.js
+++ b/src/stories/PieDoughnut.stories.js
@@ -150,13 +150,6 @@ export const DoughnutCustomCenterLabel = {
         .width=${args.width}
         .height=${args.height}
       ></kd-chart>
-      <br /><br />
-      Doughnut center labels can be customized by passing in
-      "options.doughnutLabel.line1text" and/or
-      "options.doughnutLabel.line2text". These options will accept a string,
-      number, or a function that returns a string/number. If passing a function,
-      the first parameter will give you the default value, and the second
-      parameter the context/chart.
     `;
   },
   parameters: {

--- a/src/stories/PieDoughnut.stories.js
+++ b/src/stories/PieDoughnut.stories.js
@@ -24,7 +24,7 @@ const args = {
   datasets: [
     {
       label: 'Dataset 1',
-      data: [12, 19, 3, 5, 2, 3],
+      data: [120, 190, 300, 500, 200, 300],
     },
   ],
   options: {
@@ -96,6 +96,67 @@ export const Doughnut = {
         .width=${args.width}
         .height=${args.height}
       ></kd-chart>
+    `;
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/9NrpK3rmbOk0lhlFkEPSaO/Data-Viz-Component-Library?node-id=64%3A4703&mode=dev',
+    },
+  },
+};
+
+export const DoughnutCustomCenterLabel = {
+  args: {
+    ...args,
+    chartTitle: 'Doughnut Chart',
+    description: 'With custom center labels.',
+    options: {
+      doughnutLabel: {
+        line1text: function (defaultValue, context) {
+          // example: add commas to total number
+          return defaultValue.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        },
+        line2text: 'Test',
+      },
+      scales: {
+        x: {
+          title: {
+            text: 'Color',
+          },
+        },
+        y: {
+          title: {
+            text: 'Votes',
+          },
+        },
+      },
+    },
+  },
+  render: (args) => {
+    return html`
+      <kd-chart
+        type="doughnut"
+        .chartTitle=${args.chartTitle}
+        .description=${args.description}
+        .labels=${args.labels}
+        .datasets=${args.datasets}
+        ?hideDescription=${args.hideDescription}
+        ?hideCaptions=${args.hideCaptions}
+        ?hideHeader=${args.hideHeader}
+        ?hideControls=${args.hideControls}
+        ?noBorder=${args.noBorder}
+        .options=${{ colorPalette: args.colorPalette, ...args.options }}
+        .width=${args.width}
+        .height=${args.height}
+      ></kd-chart>
+      <br /><br />
+      Doughnut center labels can be customized by passing in
+      "options.doughnutLabel.line1text" and/or
+      "options.doughnutLabel.line2text". These options will accept a string,
+      number, or a function that returns a string/number. If passing a function,
+      the first parameter will give you the default value, and the second
+      parameter the context/chart.
     `;
   },
   parameters: {


### PR DESCRIPTION
Allows doughnut center labels to be customized by passing in options for each line which can be a string, number, or a function.