### PR TITLE
fix(disableControls): added disable prop for individual controls

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -332,6 +332,36 @@
             },
             {
               "kind": "field",
+              "name": "disableDownload",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled download controls",
+              "attribute": "disableDownload"
+            },
+            {
+              "kind": "field",
+              "name": "disableFullScreen",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled full Screen controls",
+              "attribute": "disableFullScreen"
+            },
+            {
+              "kind": "field",
+              "name": "disableView",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled view controls",
+              "attribute": "disableView"
+            },
+            {
+              "kind": "field",
               "name": "customLabels",
               "type": {
                 "text": "object"
@@ -539,6 +569,33 @@
               "default": "false",
               "description": "Removes the outer border and padding.",
               "fieldName": "noBorder"
+            },
+            {
+              "name": "disableDownload",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled download controls",
+              "fieldName": "disableDownload"
+            },
+            {
+              "name": "disableFullScreen",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled full Screen controls",
+              "fieldName": "disableFullScreen"
+            },
+            {
+              "name": "disableView",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Disabled view controls",
+              "fieldName": "disableView"
             },
             {
               "name": "customLabels",

--- a/src/components/chart/chart.scss
+++ b/src/components/chart/chart.scss
@@ -203,6 +203,12 @@ table {
     &:focus {
       outline-color: var(--kd-color-border-variants-focus);
     }
+    &[disabled] {
+      color: var(--kd-color-text-link-level-disabled);
+      border: none;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
   }
 
   .download {
@@ -256,6 +262,12 @@ table {
 
       &:focus {
         outline-color: var(--kd-color-border-variants-focus);
+      }
+      &[disabled] {
+        color: var(--kd-color-text-link-level-disabled);
+        border: none;
+        cursor: not-allowed;
+        pointer-events: none;
       }
     }
   }

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -112,6 +112,18 @@ export class KDChart extends LitElement {
   @property({ type: Boolean })
   noBorder = false;
 
+  /** Disabled download controls */
+  @property({ type: Boolean })
+  disableDownload = false;
+
+  /** Disabled full Screen controls */
+  @property({ type: Boolean })
+  disableFullScreen = false;
+
+  /** Disabled view controls */
+  @property({ type: Boolean })
+  disableView = false;
+
   /** Customizable text labels. */
   @property({ type: Object })
   customLabels = {
@@ -195,6 +207,9 @@ export class KDChart extends LitElement {
     })
   );
 
+  /** ThemeObserver for canvas-container.
+   * @internal
+   */
   _themeObserver: any = new MutationObserver(() => {
     if (this.chart) {
       this.mergeOptions().then(() => {
@@ -248,6 +263,7 @@ export class KDChart extends LitElement {
                                 @click=${() => this.handleViewToggle()}
                                 aria-label=${this.customLabels.toggleView}
                                 title=${this.customLabels.toggleView}
+                                ?disabled=${this.disableView}
                               >
                                 <span slot="icon">
                                   ${this.tableView
@@ -263,6 +279,7 @@ export class KDChart extends LitElement {
                           @click=${() => this.handleFullscreen()}
                           aria-label=${this.customLabels.toggleFullscreen}
                           title=${this.customLabels.toggleFullscreen}
+                          ?disabled=${this.disableFullScreen}
                         >
                           <span slot="icon">
                             ${this.fullscreen
@@ -276,6 +293,7 @@ export class KDChart extends LitElement {
                             class="control-button"
                             aria-label=${this.customLabels.downloadMenu}
                             title=${this.customLabels.downloadMenu}
+                            ?disabled=${this.disableDownload}
                           >
                             <span slot="icon">
                               ${unsafeSVG(downloadIcon)}

--- a/src/stories/Bar.stories.js
+++ b/src/stories/Bar.stories.js
@@ -50,6 +50,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -71,6 +74,9 @@ export const Vertical = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -111,6 +117,9 @@ export const Horizontal = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -152,6 +161,9 @@ export const Stacked = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -194,6 +206,9 @@ export const HorizontalStacked = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -243,6 +258,9 @@ export const Floating = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -310,6 +328,9 @@ export const SingleLabel = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/Bubble.stories.js
+++ b/src/stories/Bubble.stories.js
@@ -81,6 +81,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -102,6 +105,9 @@ export const Bubble = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/Combo.stories.js
+++ b/src/stories/Combo.stories.js
@@ -52,6 +52,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -73,6 +76,9 @@ export const Combo = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -132,6 +138,9 @@ export const MultiAxis = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -185,6 +194,9 @@ export const ComboStacked = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -244,6 +256,9 @@ export const ComboFloating = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/Geo.stories.js
+++ b/src/stories/Geo.stories.js
@@ -33,6 +33,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'sequential01',
   noBorder: false,
   width: null,
@@ -75,6 +78,9 @@ export const WorldChoropleth = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -127,6 +133,9 @@ export const CountryChoropleth = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -172,6 +181,9 @@ export const WorldBubbleMap = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -221,6 +233,9 @@ export const CountryBubbleMap = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/Grid.stories.js
+++ b/src/stories/Grid.stories.js
@@ -14,6 +14,13 @@ export default {
 const args = {
   noBorder: false,
   height: null,
+  hideDescription: false,
+  hideCaptions: false,
+  hideHeader: false,
+  hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
 };
 
 export const Full = {
@@ -27,6 +34,13 @@ export const Full = {
           description="Full Example"
           .height=${args.height}
           ?noBorder=${args.noBorder}
+          ?hideDescription=${args.hideDescription}
+          ?hideCaptions=${args.hideCaptions}
+          ?hideHeader=${args.hideHeader}
+          ?hideControls=${args.hideControls}
+          ?disableView=${args.disableView}
+          ?disableFullScreen=${args.disableFullScreen}
+          ?disableDownload=${args.disableDownload}
           .labels=${['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange']}
           .datasets=${[
             {
@@ -68,7 +82,14 @@ export const Half = {
             chartTitle="Bar Chart"
             description="Half Example"
             .height=${args.height}
+            ?hideDescription=${args.hideDescription}
+            ?hideCaptions=${args.hideCaptions}
+            ?hideHeader=${args.hideHeader}
+            ?hideControls=${args.hideControls}
             ?noBorder=${args.noBorder}
+            ?disableView=${args.disableView}
+            ?disableFullScreen=${args.disableFullScreen}
+            ?disableDownload=${args.disableDownload}
             .labels=${['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange']}
             .datasets=${[
               {
@@ -105,6 +126,13 @@ export const Half = {
             description="Half Example"
             .height=${args.height}
             ?noBorder=${args.noBorder}
+            ?hideDescription=${args.hideDescription}
+            ?hideCaptions=${args.hideCaptions}
+            ?hideHeader=${args.hideHeader}
+            ?hideControls=${args.hideControls}
+            ?disableView=${args.disableView}
+            ?disableFullScreen=${args.disableFullScreen}
+            ?disableDownload=${args.disableDownload}
             .labels=${['Blue', 'Red', 'Orange', 'Yellow', 'Green', 'Purple']}
             .datasets=${[
               {
@@ -146,6 +174,13 @@ export const Third = {
             description="Third Example"
             .height=${args.height}
             ?noBorder=${args.noBorder}
+            ?hideDescription=${args.hideDescription}
+            ?hideCaptions=${args.hideCaptions}
+            ?hideHeader=${args.hideHeader}
+            ?hideControls=${args.hideControls}
+            ?disableView=${args.disableView}
+            ?disableFullScreen=${args.disableFullScreen}
+            ?disableDownload=${args.disableDownload}
             .labels=${['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange']}
             .datasets=${[
               {
@@ -182,6 +217,13 @@ export const Third = {
             description="Third Example"
             .height=${args.height}
             ?noBorder=${args.noBorder}
+            ?hideDescription=${args.hideDescription}
+            ?hideCaptions=${args.hideCaptions}
+            ?hideHeader=${args.hideHeader}
+            ?hideControls=${args.hideControls}
+            ?disableView=${args.disableView}
+            ?disableFullScreen=${args.disableFullScreen}
+            ?disableDownload=${args.disableDownload}
             .labels=${['Blue', 'Red', 'Orange', 'Yellow', 'Green', 'Purple']}
             .datasets=${[
               {
@@ -213,6 +255,13 @@ export const Third = {
             description="Third Example"
             .height=${args.height}
             ?noBorder=${args.noBorder}
+            ?hideDescription=${args.hideDescription}
+            ?hideCaptions=${args.hideCaptions}
+            ?hideHeader=${args.hideHeader}
+            ?hideControls=${args.hideControls}
+            ?disableView=${args.disableView}
+            ?disableFullScreen=${args.disableFullScreen}
+            ?disableDownload=${args.disableDownload}
             .labels=${['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange']}
             .datasets=${[
               {

--- a/src/stories/Line.stories.js
+++ b/src/stories/Line.stories.js
@@ -49,6 +49,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -70,6 +73,9 @@ export const Line = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -110,6 +116,9 @@ export const WithoutPoints = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -150,6 +159,9 @@ export const Curved = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -241,6 +253,9 @@ export const Area = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -314,6 +329,9 @@ export const TimeScale = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/Meter.stories.js
+++ b/src/stories/Meter.stories.js
@@ -43,6 +43,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'rag03',
   noBorder: false,
   width: null,
@@ -64,6 +67,9 @@ export const Meter = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/PieDoughnut.stories.js
+++ b/src/stories/PieDoughnut.stories.js
@@ -45,6 +45,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -66,6 +69,9 @@ export const Pie = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -92,6 +98,9 @@ export const Doughnut = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -147,6 +156,9 @@ export const DoughnutCustomCenterLabel = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/PolarArea.stories.js
+++ b/src/stories/PolarArea.stories.js
@@ -45,6 +45,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -66,6 +69,9 @@ export const PolarArea = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/Radar.stories.js
+++ b/src/stories/Radar.stories.js
@@ -49,6 +49,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -70,6 +73,9 @@ export const Radar = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/Scatter.stories.js
+++ b/src/stories/Scatter.stories.js
@@ -75,6 +75,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -96,6 +99,9 @@ export const Scatter = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}

--- a/src/stories/TreeMap.stories.js
+++ b/src/stories/TreeMap.stories.js
@@ -51,6 +51,9 @@ const args = {
   hideCaptions: false,
   hideHeader: false,
   hideControls: false,
+  disableView: false,
+  disableFullScreen: false,
+  disableDownload: false,
   colorPalette: 'categorical',
   noBorder: false,
   width: null,
@@ -73,6 +76,9 @@ export const TreeMap = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -115,6 +121,9 @@ export const Grouped = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}
@@ -166,6 +175,9 @@ export const NestedData = {
         ?hideHeader=${args.hideHeader}
         ?hideControls=${args.hideControls}
         ?noBorder=${args.noBorder}
+        ?disableView=${args.disableView}
+        ?disableFullScreen=${args.disableFullScreen}
+        ?disableDownload=${args.disableDownload}
         .options=${{ colorPalette: args.colorPalette, ...args.options }}
         .width=${args.width}
         .height=${args.height}


### PR DESCRIPTION
## Summary

To fix disable state of Widget Chart click controls issue https://github.com/kyndryl-design-system/shidoka-applications/pull/329

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [x] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [x] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file
