### PR TITLE
fix(chart): locale friendly datetime in table view

### DIFF
--- a/src/components/chart/chart.scss
+++ b/src/components/chart/chart.scss
@@ -216,3 +216,7 @@ table {
     }
   }
 }
+
+strong {
+  font-weight: 500;
+}

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -400,10 +400,24 @@ export class KDChart extends LitElement {
                             }
                           )
                       : this.datasets[0].data.map((_value: any, i: number) => {
+                          const IndexAxis = this.options.indexAxis || 'x';
+                          const NonIndexAxis = IndexAxis === 'x' ? 'y' : 'x';
+
                           return html`
                             <tr>
                               ${this.labels.length
-                                ? html`<td>${this.labels[i]}</td>`
+                                ? html`
+                                    ${this.options.scales[IndexAxis].type ===
+                                    'time'
+                                      ? html`
+                                          <td>
+                                            ${new Date(
+                                              this.labels[i]
+                                            ).toLocaleString()}
+                                          </td>
+                                        `
+                                      : html`<td>${this.labels[i]}</td>`}
+                                  `
                                 : null}
                               ${this.datasets.map((dataset) => {
                                 const dataPoint = dataset.data[i];
@@ -412,9 +426,18 @@ export class KDChart extends LitElement {
                                   this.type === 'bubbleMap' ||
                                   this.type === 'choropleth'
                                 ) {
-                                  return html`<td>
-                                    ${dataset.data[i].value}
-                                  </td>`;
+                                  return html`
+                                    <td>${dataset.data[i].value}</td>
+                                  `;
+                                } else if (
+                                  this.options.scales[NonIndexAxis].type ===
+                                  'time'
+                                ) {
+                                  return html`
+                                    <td>
+                                      ${new Date(dataPoint).toLocaleString()}
+                                    </td>
+                                  `;
                                 } else if (Array.isArray(dataPoint)) {
                                   // handle data in array format
                                   return html`
@@ -429,8 +452,25 @@ export class KDChart extends LitElement {
                                   return html`
                                     <td>
                                       ${Object.keys(dataPoint).map((key) => {
+                                        const Label =
+                                          this.options.scales[key]?.title
+                                            .text || key;
+
+                                        if (IndexAxis === key) {
+                                          return html`
+                                            <div>
+                                              <strong>${Label}:</strong>
+                                              ${new Date(
+                                                dataPoint[key]
+                                              ).toLocaleString()}
+                                            </div>
+                                          `;
+                                        }
                                         return html`
-                                          <span>${key}: ${dataPoint[key]}</span>
+                                          <div>
+                                            <strong>${Label}:</strong>
+                                            ${dataPoint[key]}
+                                          </div>
                                         `;
                                       })}
                                     </td>


### PR DESCRIPTION
## Summary

Added locale friendly conversion of date/time data in the chart table view.

## Testing Instructions

- View Line / Time Scale story
- Switch to Table view
- Observe date/time is now presented in a readable format