### PR TITLE
fix(focus): keyboard focus

### DIFF
--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -248,7 +248,6 @@ export class KDChart extends LitElement {
                         ${!this.tableDisabled
                           ? html`
                               <button
-                                tabindex="0"
                                 class="control-button"
                                 @click=${() => this.handleViewToggle()}
                                 aria-label=${this.customLabels.toggleView}
@@ -264,7 +263,6 @@ export class KDChart extends LitElement {
                           : null}
 
                         <button
-                          tabindex="0"
                           class="control-button"
                           @click=${() => this.handleFullscreen()}
                           aria-label=${this.customLabels.toggleFullscreen}
@@ -293,7 +291,6 @@ export class KDChart extends LitElement {
                             ${!this.tableDisabled
                               ? html`
                                   <button
-                                    tabindex="0"
                                     @click=${(e: Event) =>
                                       this.handleDownloadCsv(e)}
                                   >
@@ -302,14 +299,12 @@ export class KDChart extends LitElement {
                                 `
                               : null}
                             <button
-                              tabindex="0"
                               @click=${(e: Event) =>
                                 this.handleDownloadImage(e, false)}
                             >
                               ${this.customLabels.downloadPng}
                             </button>
                             <button
-                              tabindex="0"
                               @click=${(e: Event) =>
                                 this.handleDownloadImage(e, true)}
                             >

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -291,6 +291,7 @@ export class KDChart extends LitElement {
                             ${!this.tableDisabled
                               ? html`
                                   <button
+                                    tabindex="0"
                                     @click=${(e: Event) =>
                                       this.handleDownloadCsv(e)}
                                   >
@@ -299,12 +300,14 @@ export class KDChart extends LitElement {
                                 `
                               : null}
                             <button
+                              tabindex="0"
                               @click=${(e: Event) =>
                                 this.handleDownloadImage(e, false)}
                             >
                               ${this.customLabels.downloadPng}
                             </button>
                             <button
+                              tabindex="0"
                               @click=${(e: Event) =>
                                 this.handleDownloadImage(e, true)}
                             >

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -248,6 +248,7 @@ export class KDChart extends LitElement {
                         ${!this.tableDisabled
                           ? html`
                               <button
+                                tabindex="0"
                                 class="control-button"
                                 @click=${() => this.handleViewToggle()}
                                 aria-label=${this.customLabels.toggleView}
@@ -263,6 +264,7 @@ export class KDChart extends LitElement {
                           : null}
 
                         <button
+                          tabindex="0"
                           class="control-button"
                           @click=${() => this.handleFullscreen()}
                           aria-label=${this.customLabels.toggleFullscreen}
@@ -277,6 +279,7 @@ export class KDChart extends LitElement {
 
                         <div class="download">
                           <button
+                            tabindex="0"
                             class="control-button"
                             aria-label=${this.customLabels.downloadMenu}
                             title=${this.customLabels.downloadMenu}
@@ -290,6 +293,7 @@ export class KDChart extends LitElement {
                             ${!this.tableDisabled
                               ? html`
                                   <button
+                                    tabindex="0"
                                     @click=${(e: Event) =>
                                       this.handleDownloadCsv(e)}
                                   >
@@ -298,12 +302,14 @@ export class KDChart extends LitElement {
                                 `
                               : null}
                             <button
+                              tabindex="0"
                               @click=${(e: Event) =>
                                 this.handleDownloadImage(e, false)}
                             >
                               ${this.customLabels.downloadPng}
                             </button>
                             <button
+                              tabindex="0"
                               @click=${(e: Event) =>
                                 this.handleDownloadImage(e, true)}
                             >

--- a/src/stories/Bar.stories.js
+++ b/src/stories/Bar.stories.js
@@ -1,7 +1,6 @@
 import { html } from 'lit';
 import '../components/chart';
 import argTypes from '../common/config/chartArgTypes';
-import { getRandomData } from '../common/helpers/helpers';
 
 export default {
   title: 'Charts/Bar',


### PR DESCRIPTION
## Summary

**Browser : Safari**

Keyboard tab focus not working for button's


## ADO Issue Link

fixes [AB#2202652](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2202652)


https://github.com/user-attachments/assets/3ffc13e0-f4f0-4cd8-8cbf-94b6a65eac1f



## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


## ScreenRecording



**After Fix**

https://github.com/user-attachments/assets/56151ed8-c9a9-48bc-8dc4-2c3e49963069


