### PR TITLE
fix(geo): legend min vals for choropleth and bubbleMap

### DIFF
--- a/src/common/config/chartTypes/bubbleMap.js
+++ b/src/common/config/chartTypes/bubbleMap.js
@@ -61,6 +61,20 @@ export const options = (ctx) => {
         border: {
           color: LegendTicksColor,
         },
+        min: function () {
+          if (ctx.datasets && ctx.datasets.length > 0) {
+            const allData = ctx.datasets.flatMap(
+              (dataset) => dataset.data || []
+            );
+            const validValues = allData
+              .map((item) => item.value)
+              .filter((v) => typeof v === 'number');
+            if (validValues.length > 0) {
+              return Math.min(...validValues);
+            }
+          }
+          return undefined;
+        },
       },
     },
   };

--- a/src/common/config/chartTypes/choropleth.js
+++ b/src/common/config/chartTypes/choropleth.js
@@ -41,6 +41,20 @@ export const options = (ctx) => {
         border: {
           color: LegendTicksColor,
         },
+        min: function () {
+          if (ctx.datasets && ctx.datasets.length > 0) {
+            const allData = ctx.datasets.flatMap(
+              (dataset) => dataset.data || []
+            );
+            const validValues = allData
+              .map((item) => item.value)
+              .filter((v) => typeof v === 'number');
+            if (validValues.length > 0) {
+              return Math.min(...validValues);
+            }
+          }
+          return undefined;
+        },
       },
     },
   };


### PR DESCRIPTION
## Summary

_Note: Separating this from other PR for clarity_

Dev brought up a desired feature for the smallest bubble in the bubbleMap legend to display the lowest value in the dataset instead of 0. This PR implements that as well (see screenshot below).

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [x] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

`Geo` stories now show legend updates to display lowest value in the data set by default

## Screenshots

#### Bubble Map Legend Feature -- set smallest bubble to smallest value in the dataset instead of 0 (which visually doesn't really make sense)
<img width="1151" alt="Screenshot 2025-04-10 at 11 26 15 AM" src="https://github.com/user-attachments/assets/a3cd5eff-0cd6-4492-b3b0-eeeafd55a000" />
<img width="157" alt="Screenshot 2025-04-10 at 11 26 17 AM" src="https://github.com/user-attachments/assets/8ab69a78-3a85-4b73-a729-682ed4c64a52" />
