### PR TITLE
fix: dev user customization issues for html legend

### DIFF
--- a/src/common/config/chartTypes/doughnut.js
+++ b/src/common/config/chartTypes/doughnut.js
@@ -17,7 +17,7 @@ export const options = () => {
           const total = context.chart.data.datasets[0].data
             .filter(
               (dataPoint, index) =>
-                !context.chart.legend.legendItems[index].hidden
+                !context.chart.legend.legendItems[index]?.hidden
             )
             .reduce((a, b) => a + b, 0);
 

--- a/src/common/config/chartTypes/pie.js
+++ b/src/common/config/chartTypes/pie.js
@@ -17,7 +17,7 @@ export const options = () => {
           const total = context.chart.data.datasets[0].data
             .filter(
               (dataPoint, index) =>
-                !context.chart.legend.legendItems[index].hidden
+                !context.chart.legend.legendItems[index]?.hidden
             )
             .reduce((a, b) => a + b, 0);
 

--- a/src/common/legend/htmlRenderer.js
+++ b/src/common/legend/htmlRenderer.js
@@ -264,7 +264,7 @@ export function renderHTMLLegend(chart, container, options) {
       }
 
       container.dispatchEvent(
-        new CustomEvent('legend-item-click', {
+        new CustomEvent('on-click', {
           detail: info,
           bubbles: true,
           composed: true,
@@ -273,7 +273,6 @@ export function renderHTMLLegend(chart, container, options) {
     };
 
     buttonWrapper.addEventListener('click', toggleItemVisibility);
-    // Also add keyboard support for toggles
     buttonWrapper.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();

--- a/src/common/legend/htmlRenderer.js
+++ b/src/common/legend/htmlRenderer.js
@@ -291,61 +291,61 @@ export function renderHTMLLegend(chart, container, options) {
   if (legendItems.length > 0) {
     legendItems.forEach((button, index) => {
       button.addEventListener('keydown', (e) => {
-        let nextIndex, prevIndex;
-
-        if (opts.layout === 'vertical' || opts.columns === 1) {
-          if (e.key === 'ArrowDown') {
-            nextIndex = (index + 1) % legendItems.length;
-            legendItems[nextIndex].focus();
-            e.preventDefault();
-          } else if (e.key === 'ArrowUp') {
-            prevIndex = (index - 1 + legendItems.length) % legendItems.length;
-            legendItems[prevIndex].focus();
+        const navigateTo = (targetIndex) => {
+          if (targetIndex >= 0 && targetIndex < legendItems.length) {
+            legendItems[targetIndex].focus();
             e.preventDefault();
           }
-        } else if (opts.columns > 1) {
+        };
+
+        if (opts.columns > 1) {
           const totalRows = Math.ceil(legendItems.length / opts.columns);
           const currentRow = Math.floor(index / opts.columns);
           const currentCol = index % opts.columns;
 
-          if (e.key === 'ArrowRight') {
-            nextIndex =
-              currentRow * opts.columns + ((currentCol + 1) % opts.columns);
-            if (nextIndex < legendItems.length) {
-              legendItems[nextIndex].focus();
-              e.preventDefault();
-            }
-          } else if (e.key === 'ArrowLeft') {
-            prevIndex =
-              currentRow * opts.columns +
-              ((currentCol - 1 + opts.columns) % opts.columns);
-            legendItems[prevIndex].focus();
-            e.preventDefault();
-          } else if (e.key === 'ArrowDown') {
-            nextIndex =
-              ((currentRow + 1) % totalRows) * opts.columns + currentCol;
-            if (nextIndex < legendItems.length) {
-              legendItems[nextIndex].focus();
-              e.preventDefault();
-            }
-          } else if (e.key === 'ArrowUp') {
-            prevIndex =
-              ((currentRow - 1 + totalRows) % totalRows) * opts.columns +
-              currentCol;
-            if (prevIndex < legendItems.length) {
-              legendItems[prevIndex].focus();
-              e.preventDefault();
-            }
+          switch (e.key) {
+            case 'ArrowRight':
+              navigateTo(
+                currentRow * opts.columns + ((currentCol + 1) % opts.columns)
+              );
+              break;
+            case 'ArrowLeft':
+              navigateTo(
+                currentRow * opts.columns +
+                  ((currentCol - 1 + opts.columns) % opts.columns)
+              );
+              break;
+            case 'ArrowDown':
+              navigateTo(
+                ((currentRow + 1) % totalRows) * opts.columns + currentCol
+              );
+              break;
+            case 'ArrowUp':
+              navigateTo(
+                ((currentRow - 1 + totalRows) % totalRows) * opts.columns +
+                  currentCol
+              );
+              break;
+          }
+        } else if (opts.layout === 'vertical' || opts.columns === 1) {
+          switch (e.key) {
+            case 'ArrowDown':
+              navigateTo((index + 1) % legendItems.length);
+              break;
+            case 'ArrowUp':
+              navigateTo((index - 1 + legendItems.length) % legendItems.length);
+              break;
           }
         } else {
-          if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-            nextIndex = (index + 1) % legendItems.length;
-            legendItems[nextIndex].focus();
-            e.preventDefault();
-          } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-            prevIndex = (index - 1 + legendItems.length) % legendItems.length;
-            legendItems[prevIndex].focus();
-            e.preventDefault();
+          switch (e.key) {
+            case 'ArrowRight':
+            case 'ArrowDown':
+              navigateTo((index + 1) % legendItems.length);
+              break;
+            case 'ArrowLeft':
+            case 'ArrowUp':
+              navigateTo((index - 1 + legendItems.length) % legendItems.length);
+              break;
           }
         }
       });

--- a/src/common/plugins/doughnutLabel.js
+++ b/src/common/plugins/doughnutLabel.js
@@ -13,7 +13,7 @@ export default {
 
       // get sum of all visible data points
       const total = chart.config.data.datasets[0].data
-        .filter((dataPoint, index) => !chart.legend.legendItems[index].hidden)
+        .filter((dataPoint, index) => !chart.legend.legendItems[index]?.hidden)
         .reduce((a, b) => a + b, 0);
 
       ctx.textAlign = 'center';

--- a/src/common/plugins/htmlLegendPlugin.ts
+++ b/src/common/plugins/htmlLegendPlugin.ts
@@ -9,6 +9,7 @@ export interface LegendItemClickInfo {
   dataIndex?: number;
   datasetIndex?: number;
   element: HTMLElement;
+  event?: Event;
 }
 
 export interface HtmlLegendPluginOptions {
@@ -23,6 +24,12 @@ export interface HtmlLegendPluginOptions {
   onItemClick?: (info: LegendItemClickInfo) => void;
   adjustChartHeight?: boolean;
   reservedLegendHeight?: number;
+  columns?: number;
+  labelFormatter?: (label: string, item: any) => string;
+  itemClassResolver?: (item: any) => string | null;
+  searchEnabled?: boolean;
+  searchPlaceholder?: string;
+  position?: 'top' | 'bottom' | 'left' | 'right';
 }
 
 export const htmlLegendPlugin = {

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -19,6 +19,7 @@ import doughnutLabelPlugin from '../../common/plugins/doughnutLabel';
 import meterGaugePlugin from '../../common/plugins/meterGaugeNeedle';
 import gradientLegendPlugin from '../../common/plugins/gradientLegend';
 import { renderHTMLLegend } from '../../common/legend';
+import { htmlLegendPlugin } from '../../common/plugins/htmlLegendPlugin';
 import a11yPlugin from 'chartjs-plugin-a11y-legend';
 import datalabelsPlugin from 'chartjs-plugin-datalabels';
 import annotationPlugin from 'chartjs-plugin-annotation';
@@ -606,11 +607,14 @@ export class KDChart extends LitElement {
 
   override connectedCallback() {
     super.connectedCallback();
-
-    this._themeObserver.observe(
-      document.querySelector('meta[name="color-scheme"]'),
-      { attributes: true }
-    );
+    try {
+      const meta = document.querySelector('meta[name="color-scheme"]');
+      if (meta instanceof Node) {
+        this._themeObserver.observe(meta, { attributes: true });
+      }
+    } catch (error) {
+      console.warn('Failed to set up theme observer:', error);
+    }
   }
 
   override disconnectedCallback() {
@@ -628,19 +632,41 @@ export class KDChart extends LitElement {
   private generateScrollableLegend() {
     if (!this.chart || !this.useHtmlLegend) return;
 
-    const legendContainer = this.shadowRoot?.querySelector(
+    const legendContainer = this.shadowRoot!.querySelector(
       '.html-legend-container'
-    );
+    ) as HTMLElement;
     if (!legendContainer) return;
 
-    const legendOptions = this.mergedOptions.plugins.customLegend;
+    const htmlLegendOpts = this.mergedOptions.plugins.htmlLegend || {};
 
-    renderHTMLLegend(this.chart, legendContainer as HTMLElement, {
+    const opts: Record<string, unknown> = {
       maxHeight: this.htmlLegendMaxHeight,
-      boxWidth: legendOptions?.boxWidth || 16,
-      boxHeight: legendOptions?.boxHeight || 16,
-      borderRadius: legendOptions?.borderRadius || 2,
+    };
+
+    const availableOptions = [
+      'boxWidth',
+      'boxHeight',
+      'borderRadius',
+      'className',
+      'itemClassName',
+      'layout',
+      'fontSize',
+      'boxMargin',
+      'adjustChartHeight',
+      'reservedLegendHeight',
+    ];
+
+    availableOptions.forEach((optionName) => {
+      if (htmlLegendOpts[optionName] !== undefined) {
+        opts[optionName] = htmlLegendOpts[optionName];
+      }
     });
+
+    if (typeof htmlLegendOpts.onItemClick === 'function') {
+      opts.onItemClick = htmlLegendOpts.onItemClick;
+    }
+
+    renderHTMLLegend(this.chart, legendContainer, opts);
   }
 
   override updated(changedProps: any) {
@@ -741,43 +767,28 @@ export class KDChart extends LitElement {
    * and options.
    */
   private initChart() {
-    const ignoredTypes = ['choropleth', 'treemap', 'bubbleMap'];
-
-    // Configure chart options
-    Chart.defaults.color = getTokenThemeVal('--kd-color-text-level-primary');
-
-    // We already handled legend config in mergeOptions
-
-    // Select plugin when type='meter'. Otherwise both plugins (meterGaugePlugin & doughnutLabelPlugin) are called
-    const pluginSelectForDoghnutMeter =
+    const pluginSelect =
       this.type === 'meter' ? meterGaugePlugin : doughnutLabelPlugin;
 
-    let plugins = [
+    const chartPlugins = [
       canvasBackgroundPlugin,
-      pluginSelectForDoghnutMeter,
+      pluginSelect,
       gradientLegendPlugin,
       ...this.plugins,
+      a11yPlugin,
     ];
 
-    // only add certain plugins for standard chart types
-    if (!ignoredTypes.includes(this.type)) {
-      // plugins = [...plugins, a11yPlugin, musicPlugin];
-      plugins = [...plugins, a11yPlugin];
+    // add htmlLegendPlugin if useHtmlLegend is enabled
+    if (this.useHtmlLegend) {
+      chartPlugins.push(htmlLegendPlugin);
     }
 
-    if (this.chart) {
-      this.chart.destroy();
-    }
-
+    if (this.chart) this.chart.destroy();
     this.chart = new Chart(this.canvas, {
-      //type: this.type,
       type: this.type === 'meter' ? 'doughnut' : this.type,
-      data: {
-        labels: this.labels,
-        datasets: this.mergedDatasets,
-      },
+      data: { labels: this.labels, datasets: this.mergedDatasets },
       options: this.mergedOptions,
-      plugins: plugins,
+      plugins: chartPlugins,
     });
 
     this.generateScrollableLegend();
@@ -791,79 +802,58 @@ export class KDChart extends LitElement {
     const radialTypes = ['pie', 'doughnut', 'radar', 'polarArea', 'meter'];
     const ignoredTypes = ['choropleth', 'treemap', 'bubbleMap'];
 
-    const additionalTypeImports: any = [];
+    // dynamically import type-specific configs
+    const additionalTypeImports: any[] = [];
     this.datasets.forEach((dataset) => {
-      // get chart types from datasets so we can import additional configs
       if (dataset.type) {
         additionalTypeImports.push(
           import(`../../common/config/chartTypes/${dataset.type}.js`)
         );
       }
     });
-
-    // import main and additional chart type configs
     const chartTypeConfigs = await Promise.all([
       import(`../../common/config/chartTypes/${this.type}.js`),
       ...additionalTypeImports,
     ]);
 
-    // start with global options
     let mergedOptions: any = globalOptions(this);
+    mergedOptions.plugins = mergedOptions.plugins || {};
 
-    // Configure legend display based on useHtmlLegend property
-    if (!this.useHtmlLegend) {
-      // Enable built-in Chart.js legend when HTML legend is disabled
-      mergedOptions.plugins = mergedOptions.plugins || {};
+    if (this.useHtmlLegend) {
+      mergedOptions.plugins.legend = { display: false };
+      mergedOptions.plugins.htmlLegend = mergedOptions.plugins.htmlLegend || {};
+    } else {
       mergedOptions.plugins.legend = mergedOptions.plugins.legend || {};
       mergedOptions.plugins.legend.display = true;
-
-      // Disable customLegend options when using built-in legend
-      if (mergedOptions.plugins.customLegend) {
-        mergedOptions.plugins.customLegend.display = false;
-      }
     }
 
-    // merge global type options
+    // merge radial vs non-radial defaults
     if (radialTypes.includes(this.type)) {
       mergedOptions = deepmerge(mergedOptions, globalOptionsRadial(this));
     } else if (!ignoredTypes.includes(this.type)) {
       mergedOptions = deepmerge(mergedOptions, globalOptionsNonRadial(this));
     }
 
-    const mergedDatasets: any = JSON.parse(JSON.stringify(this.datasets));
+    const mergedDatasets: any[] = JSON.parse(JSON.stringify(this.datasets));
 
-    chartTypeConfigs.forEach((chartTypeConfig: any) => {
-      // merge all of the imported chart type options with the global options
-      mergedOptions = deepmerge(mergedOptions, chartTypeConfig.options(this));
-
-      // merge all of the imported chart type dataset options
-      mergedDatasets.forEach((dataset: any, index: number) => {
-        if (
-          (!dataset.type && chartTypeConfig.type === this.type) ||
-          dataset.type === chartTypeConfig.type
-        ) {
-          mergedDatasets[index] = deepmerge(
-            dataset,
-            chartTypeConfig.datasetOptions(this, index)
-          );
+    chartTypeConfigs.forEach((cfg: any) => {
+      mergedOptions = deepmerge(mergedOptions, cfg.options(this));
+      mergedDatasets.forEach((ds: any, i: number) => {
+        if ((!ds.type && cfg.type === this.type) || ds.type === cfg.type) {
+          mergedDatasets[i] = deepmerge(ds, cfg.datasetOptions(this, i));
         }
       });
     });
 
     if (this.options) {
-      // merge any consumer supplied options with defaults
       mergedOptions = deepmerge(mergedOptions, this.options);
     }
     this.mergedOptions = mergedOptions;
 
-    // merge default chart type dataset options with consumer supplied datasets
-    mergedDatasets.forEach((dataset: object, index: number) => {
-      const customDeepmerge = deepmergeCustom({
-        mergeArrays: false,
-      });
-      mergedDatasets[index] = customDeepmerge(dataset, this.datasets[index]);
+    mergedDatasets.forEach((ds: object, i: number) => {
+      const customDeep = deepmergeCustom({ mergeArrays: false });
+      mergedDatasets[i] = customDeep(ds, this.datasets[i]);
     });
-
     this.mergedDatasets = mergedDatasets;
   }
 

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -683,7 +683,7 @@ export class KDChart extends LitElement {
         }
 
         this.dispatchEvent(
-          new CustomEvent('legend-item-click', {
+          new CustomEvent('on-click', {
             detail: info,
             bubbles: true,
             composed: true,

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -915,6 +915,10 @@ export class KDChart extends LitElement {
         type: this.chart.config.type,
       };
 
+      const originalHidden = this.chart.data.datasets.map(
+        (_: unknown, i: number) => this.chart.getDatasetMeta(i).hidden
+      );
+
       try {
         if (!this.chart.options.plugins) {
           this.chart.options.plugins = {};
@@ -974,9 +978,10 @@ export class KDChart extends LitElement {
         document.body.removeChild(a);
 
         context.restore();
-
-        this.chart.data = originalConfig.data;
         this.chart.options = originalConfig.options;
+        originalHidden.forEach((hidden: boolean, i: number) => {
+          this.chart.getDatasetMeta(i).hidden = hidden;
+        });
         this.chart.update();
       } catch (error) {
         console.error('Error exporting chart with legend:', error);

--- a/src/stories/Legend.mdx
+++ b/src/stories/Legend.mdx
@@ -13,10 +13,6 @@ Legends help users identify the data series displayed in a chart. The Shidoka Ch
 2. **Built-in HTML Legend** - An enhanced HTML legend with better styling and scrollability
 3. **External HTML Legends** - Custom legends rendered outside the chart component
 
-## Built-in Legend Usage
-
-The chart component has a `useHtmlLegend` attribute that controls which legend to use.
-
 ### Canvas Legend
 
 This uses the default Chart.js canvas-rendered legend:
@@ -36,6 +32,10 @@ This uses the default Chart.js canvas-rendered legend:
 ```
 
 ### HTML Legend
+
+The HTML legend utilizes the [chartjs HTML Legend](https://www.chartjs.org/docs/latest/samples/legend/html.html) and is enabled by setting the `useHtmlLegend` attribute to `true`. This renders the legend as a separate HTML element outside the canvas, allowing for more customization and styling options.
+
+````html
 
 > ⚠️ **Warning:** Implementing the HTML legend should be done with caution. Depending on your implementation approach, it may lead to breakages or inconsistencies in your chart's appearance or behavior. Always test thoroughly across different browsers and with various data configurations to ensure reliability.
 
@@ -70,7 +70,7 @@ This uses an enhanced HTML-based legend with better styling and scrollability:
     }
   }}
 ></kd-chart>
-```
+````
 
 The HTML legend can be configured using the `plugins.htmlLegend` options in the chart configuration:
 

--- a/src/stories/Legend.mdx
+++ b/src/stories/Legend.mdx
@@ -242,7 +242,7 @@ When you have multiple chart instances on a page, you can synchronize them using
     type="bar"
     useHtmlLegend
     .datasets=${datasets}
-    @legend-item-click=${(e) => syncAllCharts(e.detail, 'bar-chart')}
+    @on-click=${(e) => syncAllCharts(e.detail, 'bar-chart')}
   ></kd-chart>
 
   <kd-chart
@@ -250,7 +250,7 @@ When you have multiple chart instances on a page, you can synchronize them using
     type="line"
     useHtmlLegend
     .datasets=${datasets}
-    @legend-item-click=${(e) => syncAllCharts(e.detail, 'line-chart')}
+    @on-click=${(e) => syncAllCharts(e.detail, 'line-chart')}
   ></kd-chart>
 </div>
 ```
@@ -329,30 +329,65 @@ function collectHiddenDatasets() {
 }
 ```
 
-### Using with Storybook Actions
+### Debugging With Storybook Actions
+
+To debug legend interactions in Storybook, the event listener approach is recommended:
 
 ```javascript
-import { action } from '@storybook/addon-actions';
+// In your Storybook story
+export const WithLegendDebugging = () => {
+  const container = document.createElement('div');
+  container.innerHTML = `
+    <kd-chart
+      id="debug-chart"
+      type="bar"
+      useHtmlLegend
+      .datasets=${sampleData.datasets}
+      .labels=${sampleData.labels}
+    ></kd-chart>
+  `;
 
-renderHTMLLegend(chart, container, {
-  maxHeight: 100,
-  onItemClick: (info) => {
-    const actionData = {
-      label: info.label,
-      isHidden: info.isHidden,
-    };
+  // Listen for legend click events at the container level
+  container.addEventListener('on-click', (event) => {
+    action('legend-clicked')(event.detail);
+  });
 
-    if (info.datasetIndex !== undefined) {
-      actionData.datasetIndex = info.datasetIndex;
-    }
+  return container;
+};
 
-    if (info.dataIndex !== undefined) {
-      actionData.dataIndex = info.dataIndex;
-    }
-
-    action('on-click')(actionData);
+WithLegendDebugging.parameters = {
+  docs: {
+    description: {
+      story:
+        'This example shows how to debug legend interactions using Storybook actions.',
+    },
   },
-});
+};
+```
+
+Alternatively, you can use the `htmlLegendOptions` to set up debugging:
+
+```javascript
+export const LegendWithStorybook = {
+  render: () => html`
+    <kd-chart
+      type="bar"
+      .datasets=${sampleData.datasets}
+      .labels=${sampleData.labels}
+      useHtmlLegend
+      .htmlLegendOptions=${{
+        onItemClick: (info) => {
+          action('legend-click')({
+            label: info.label,
+            isHidden: info.isHidden,
+            datasetIndex: info.datasetIndex,
+            dataIndex: info.dataIndex,
+          });
+        },
+      }}
+    ></kd-chart>
+  `,
+};
 ```
 
 ### Callback Information

--- a/src/stories/Legend.mdx
+++ b/src/stories/Legend.mdx
@@ -74,14 +74,19 @@ This uses an enhanced HTML-based legend with better styling and scrollability:
 
 The HTML legend can be configured using the `plugins.htmlLegend` options in the chart configuration:
 
-| Option                 | Description                              | Default          |
-| ---------------------- | ---------------------------------------- | ---------------- |
-| `maxHeight`            | Maximum height before scrolling begins   | 100px            |
-| `containerClass`       | CSS class for the legend container       | 'shidoka-legend' |
-| `layout`               | Legend layout orientation                | 'horizontal'     |
-| `onItemClick`          | Callback when a legend item is clicked   | null             |
-| `adjustChartHeight`    | Auto-adjust chart height for consistency | true             |
-| `reservedLegendHeight` | Base space to reserve for legend (px)    | 40               |
+| Option                 | Description                                            | Default               |
+| ---------------------- | ------------------------------------------------------ | --------------------- |
+| `maxHeight`            | Maximum height before scrolling begins                 | 100px                 |
+| `className`            | CSS class for the legend container                     | 'shidoka-legend'      |
+| `itemClassName`        | CSS class for the legend items                         | 'shidoka-legend-item' |
+| `layout`               | Legend layout orientation ('horizontal' or 'vertical') | 'horizontal'          |
+| `onItemClick`          | Callback when a legend item is clicked                 | null                  |
+| `adjustChartHeight`    | Auto-adjust chart height for consistency               | true                  |
+| `reservedLegendHeight` | Base space to reserve for legend (px)                  | 40                    |
+| `columns`              | Number of columns for grid layout (0 for auto flow)    | 0                     |
+| `labelFormatter`       | Function to format labels: (label, item) => string     | null                  |
+| `itemClassResolver`    | Function to add custom classes: (item) => string       | null                  |
+| `position`             | Position of legend ('top', 'bottom', 'left', 'right')  | 'bottom'              |
 
 ## External Custom Legends
 
@@ -103,6 +108,10 @@ renderHTMLLegend(chart, container, {
   className: 'shidoka-legend', // CSS class for legend
   itemClassName: 'shidoka-legend-item', // CSS class for legend items
   layout: 'horizontal', // Legend layout orientation ('horizontal' or 'vertical')
+  columns: 3, // Optional: Use grid layout with 3 columns
+  position: 'right', // Optional: Position the legend ('top', 'bottom', 'left', 'right')
+  labelFormatter: (label, item) => `${label} (${item.color})`, // Optional: Format labels
+  itemClassResolver: (item) => (item.isHidden ? 'hidden-item' : null), // Optional: Add custom classes
 });
 ```
 
@@ -138,7 +147,11 @@ renderBoxedLegend(chart, container, {
 
 ## Handling Large Legends
 
-For charts with many data points, legends can become large. The HTML legend automatically adds scrolling when items exceed the container size. This behavior is demonstrated in the HTMLLegendOverflow and DoughnutLegendOverflow examples below.
+For charts with many data points, legends can become large. The HTML legend offers several ways to manage large datasets:
+
+1. **Scrollable Container**: Automatically adds scrolling when items exceed the container size
+2. **Grid Layout**: Organize items in multi-column grids for better use of space
+3. **Custom Positioning**: Position the legend on any side of the chart
 
 ### Customizing Scrollable Legends
 
@@ -178,23 +191,145 @@ The HTML Legend is fully keyboard accessible, providing an equivalent experience
 - each legend item is focusable and can be toggled with `Enter` or `Space` keys
 - Arrow keys can be used to navigate between legend items without having to Tab through each one
 
-## Capturing Legend Item Interactions
+## Integrating Legend with External Systems
 
-Listen for the `on-click` DOM event on your container:
+The HTML legend can interact with external systems like APIs, state management solutions, or analytics platforms.
 
-```html
-<div
-  id="legend-container"
-  @legend-item-click=${(e: CustomEvent) => action('legendItemClick')(e.detail)}
-  style="margin-top:10px; padding:8px; border:1px solid var(--kd-color-border-variants-light)"
-></div>
+### Using the onItemClick Handler
+
+The `onItemClick` handler provides comprehensive data about the clicked legend item:
+
+```javascript
+<kd-chart
+  type="bar"
+  useHtmlLegend
+  .htmlLegendOptions=${{
+    onItemClick: (info) => {
+      // Access to full chart instance
+      const chart = info.chart;
+
+      // Get detailed information about the clicked item
+      const { label, isHidden, datasetIndex, dataIndex } = info;
+
+      // Update external data source
+      externalDataStore.updateVisibility(datasetIndex, !isHidden);
+
+      // Log to analytics
+      analyticsService.track('chart_interaction', {
+        label,
+        isHidden,
+        chartType: chart.config.type
+      });
+
+      // Update other UI components
+      notifyOtherComponents({
+        type: 'LEGEND_CLICK',
+        payload: info
+      });
+    }
+  }}
+></kd-chart>
 ```
 
-This bubbles up from each `<li>` toggle and sends the same info object as onItemClick.
+### Coordinating Multiple Charts
+
+When you have multiple chart instances on a page, you can synchronize them using the legend click events:
+
+```html
+<div class="dashboard-container">
+  <kd-chart
+    id="bar-chart"
+    type="bar"
+    useHtmlLegend
+    .datasets=${datasets}
+    @legend-item-click=${(e) => syncAllCharts(e.detail, 'bar-chart')}
+  ></kd-chart>
+
+  <kd-chart
+    id="line-chart"
+    type="line"
+    useHtmlLegend
+    .datasets=${datasets}
+    @legend-item-click=${(e) => syncAllCharts(e.detail, 'line-chart')}
+  ></kd-chart>
+</div>
+```
+
+```javascript
+/**
+ * Synchronizes legend item visibility across all charts
+ * @param {Object} info - The legend click info object
+ * @param {string} sourceChartId - ID of the chart that triggered the event
+ */
+function syncAllCharts(info, sourceChartId) {
+  const { datasetIndex, isHidden, label } = info;
+
+  console.log(`Legend item "${label}" clicked on ${sourceChartId}`);
+
+  // Update all other charts with the same dataset structure
+  document.querySelectorAll('kd-chart').forEach((chartElement) => {
+    if (chartElement.id !== sourceChartId) {
+      // Get the Chart.js instance from the element
+      const chartInstance = chartElement.chart;
+
+      if (!chartInstance) return;
+
+      // Different chart types use different methods to set visibility
+      if (
+        chartInstance.data &&
+        chartInstance.data.datasets &&
+        datasetIndex !== undefined
+      ) {
+        // For dataset-based charts (bar, line, etc.)
+        const meta = chartInstance.getDatasetMeta(datasetIndex);
+        if (meta) {
+          meta.hidden = isHidden;
+          chartInstance.update();
+        }
+      } else if (datasetIndex !== undefined) {
+        // For pie/doughnut charts that use dataIndex instead
+        chartInstance.toggleDataVisibility(datasetIndex);
+        chartInstance.update();
+      }
+
+      // If you've implemented custom methods on kd-chart:
+      // chartElement.updateDatasetVisibility(datasetIndex, isHidden);
+    }
+  });
+
+  // Optionally update any related UI elements
+  updateLegendHighlighting(label, isHidden);
+
+  // You could also sync with external data storage
+  saveUserPreferences({
+    hiddenDatasets: collectHiddenDatasets(),
+  });
+}
+
+/**
+ * Collects currently hidden datasets across all charts
+ * @returns {Array} - Array of hidden dataset indices
+ */
+function collectHiddenDatasets() {
+  const hiddenDatasets = new Set();
+
+  document.querySelectorAll('kd-chart').forEach((chartElement) => {
+    const chart = chartElement.chart;
+    if (!chart) return;
+
+    chart.data.datasets.forEach((dataset, index) => {
+      const meta = chart.getDatasetMeta(index);
+      if (meta && meta.hidden) {
+        hiddenDatasets.add(index);
+      }
+    });
+  });
+
+  return Array.from(hiddenDatasets);
+}
+```
 
 ### Using with Storybook Actions
-
-For components developed in Storybook, you can easily integrate with Storybook Actions to monitor legend interactions:
 
 ```javascript
 import { action } from '@storybook/addon-actions';
@@ -220,8 +355,6 @@ renderHTMLLegend(chart, container, {
 });
 ```
 
-This will log all legend item interactions to the Storybook Actions panel, making it easy to debug and test your chart components.
-
 ### Callback Information
 
 The `info` object passed to the callback contains:
@@ -233,15 +366,43 @@ The `info` object passed to the callback contains:
 - `dataIndex` or `datasetIndex`: Index of the data or dataset (depending on chart type)
 - `element`: Reference to the DOM element that was clicked
 
+### Grid Layout Example
+
+```html
+<kd-chart
+  type="bar"
+  useHtmlLegend
+  .htmlLegendOptions=${{
+    columns: 3,
+    maxHeight: 200
+  }}
+></kd-chart>
+```
+
+### Custom Positioning Example
+
+```html
+<kd-chart
+  type="bar"
+  useHtmlLegend
+  .htmlLegendOptions=${{
+    position: 'right',
+    layout: 'vertical'
+  }}
+></kd-chart>
+```
+
 The HTML legend renders with the following structural elements that you can target for styling:
 
 ```
-div.shidoka-legend (or your custom className)
-  └── div.shidoka-legend-scroll-content
+div.shidoka-legend-container
+  └── div.shidoka-legend
        └── ul.shidoka-legend-items
             └── li.shidoka-legend-item
-                 ├── span.shidoka-legend-item-color
-                 └── span.shidoka-legend-item-label
+                 └── button.shidoka-legend-item-button
+                      ├── span.shidoka-legend-item-color
+                      └── span.shidoka-legend-item-label
+                           └── span.shidoka-legend-item-value (for pie/doughnut charts)
 ```
 
 <style>

--- a/src/stories/Legend.mdx
+++ b/src/stories/Legend.mdx
@@ -401,6 +401,86 @@ The `info` object passed to the callback contains:
 - `dataIndex` or `datasetIndex`: Index of the data or dataset (depending on chart type)
 - `element`: Reference to the DOM element that was clicked
 
+### Angular Integration Example
+
+When using the chart in an Angular application, you can capture the legend click events to filter your data:
+
+```typescript
+import { Component, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
+import { DataService } from '../services/data.service';
+
+@Component({
+  selector: 'app-sales-dashboard',
+  template: `
+    <kd-chart
+      #salesChart
+      type="bar"
+      [useHtmlLegend]="true"
+      [chartTitle]="'Sales Data'"
+      [labels]="chartLabels"
+      [datasets]="chartDatasets"
+    >
+    </kd-chart>
+  `,
+})
+export class SalesDashboardComponent implements AfterViewInit {
+  @ViewChild('salesChart') chartRef!: ElementRef;
+  chartLabels: string[] = [];
+  chartDatasets: any[] = [];
+
+  constructor(private dataService: DataService) {
+    this.loadInitialData();
+  }
+
+  ngAfterViewInit(): void {
+    // Add event listener for legend clicks
+    this.chartRef.nativeElement.addEventListener('on-click', (e: CustomEvent) =>
+      this.handleLegendClick(e)
+    );
+  }
+
+  handleLegendClick(event: CustomEvent): void {
+    const { label, isHidden, datasetIndex } = event.detail;
+
+    console.log(`Dataset '${label}' is now ${isHidden ? 'hidden' : 'visible'}`);
+
+    // call API with filtered categories
+    const hiddenCategories = this.getHiddenCategories();
+
+    this.dataService.getFilteredData(hiddenCategories).subscribe((data) => {
+      // update other components with filtered data
+      this.updateRelatedComponents(data);
+    });
+  }
+
+  getHiddenCategories(): string[] {
+    const chart = this.chartRef.nativeElement.chart;
+    const hidden: string[] = [];
+
+    if (chart) {
+      chart.data.datasets.forEach((dataset: any, index: number) => {
+        if (chart.getDatasetMeta(index).hidden) {
+          hidden.push(dataset.label);
+        }
+      });
+    }
+
+    return hidden;
+  }
+
+  loadInitialData(): void {
+    this.dataService.getData().subscribe((data) => {
+      this.chartLabels = data.labels;
+      this.chartDatasets = data.datasets;
+    });
+  }
+
+  updateRelatedComponents(data: any): void {
+    // update tables, metrics, or other visualizations
+  }
+}
+```
+
 ### Grid Layout Example
 
 ```html

--- a/src/stories/Legend.stories.js
+++ b/src/stories/Legend.stories.js
@@ -198,16 +198,7 @@ export const InternalDoughnutOverflow = {
     useHtmlLegend: true,
     htmlLegendMaxHeight: 150,
     chartTitle: 'Doughnut Chart with Internal HTML Legend Overflow',
-    labels: [
-      'Red',
-      'Blue',
-      'Green',
-      'Yellow',
-      'Purple',
-      'Orange',
-      'Pink',
-      'Plum',
-    ],
+    labels: manyLabels.slice(0, 50),
     datasets: [{ data: randomData(50) }],
   },
   render: (args) => html`

--- a/src/stories/Legend.stories.js
+++ b/src/stories/Legend.stories.js
@@ -198,7 +198,16 @@ export const InternalDoughnutOverflow = {
     useHtmlLegend: true,
     htmlLegendMaxHeight: 150,
     chartTitle: 'Doughnut Chart with Internal HTML Legend Overflow',
-    labels: manyLabels.slice(0, 50),
+    labels: [
+      'Red',
+      'Blue',
+      'Green',
+      'Yellow',
+      'Purple',
+      'Orange',
+      'Pink',
+      'Plum',
+    ],
     datasets: [{ data: randomData(50) }],
   },
   render: (args) => html`


### PR DESCRIPTION
## Summary

Addressing some observed issues with the customization of the new html legend as it is consumed by the first user, cleaning up code, improving documentation and customizability of the html legend.

Issues observed:
1. chart positioning looks off (_dev user doesn't seem to be importing the global shidoka styles correctly_)

2. legend click method is not being called when applied in a consuming repository
#### Their previous Shidoka v1 vs. Shidoka v2 charts implementation:
![79b49c1c-fd15-46e1-b246-5b68bcab87f6](https://github.com/user-attachments/assets/2bb6ec12-bc56-4577-9f81-270c88828e8e)
![bf21b036-e1b0-4c65-9b45-17e55549f4aa](https://github.com/user-attachments/assets/12284f7c-dca7-4ca0-8b22-098220bcd97e)

3. error observed in console
![99f120cd-01e7-4d6d-90d9-5f07c31744b2](https://github.com/user-attachments/assets/0374356d-6f9e-48b5-af69-e9eeac294534)

4. when all items in the doughnut chart are de-selected, there is an empty ring, when there should not be anything at all (_again, likely an issue with global shidoka-charts library importing and instantiation_)
![a4e66999-2bfa-447b-b03f-155a59950645](https://github.com/user-attachments/assets/be5b2373-18a8-4346-8a4f-b53f636ef656)
