### PR TITLE
fix: ux box plot violin plot updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@kyndryl-design-system/shidoka-foundation": "^2.1.4",
+        "@kyndryl-design-system/shidoka-foundation": "^2.4.12",
         "@kyndryl-design-system/shidoka-icons": "^2.0.0",
         "@sgratzl/chartjs-chart-boxplot": "^4.4.4",
         "chart.js": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@kyndryl-design-system/shidoka-foundation": "^2.0.0",
+        "@kyndryl-design-system/shidoka-foundation": "^2.1.4",
         "@kyndryl-design-system/shidoka-icons": "^2.0.0",
         "@sgratzl/chartjs-chart-boxplot": "^4.4.4",
         "chart.js": "^4.4.0",
@@ -4199,9 +4199,9 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@kyndryl-design-system/shidoka-foundation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.0.0.tgz",
-      "integrity": "sha512-YD7pwLNqmVlG9q0jLsh5COs8zc5Ie+nDYktt7iF4dW+tagED9gigGx+uM+OCS93cmmZ+IIS1zcdaDctfdcfKvQ=="
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.4.12.tgz",
+      "integrity": "sha512-ru+HQUuFILO9zDYfw0zODTcfRs1OGvMbrJrvmYS/I9YDjsHT0n2PO3320E/uPozohDlFen+W1nBpTbHCM4K54w=="
     },
     "node_modules/@kyndryl-design-system/shidoka-icons": {
       "version": "2.0.0",
@@ -28023,9 +28023,9 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "@kyndryl-design-system/shidoka-foundation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.0.0.tgz",
-      "integrity": "sha512-YD7pwLNqmVlG9q0jLsh5COs8zc5Ie+nDYktt7iF4dW+tagED9gigGx+uM+OCS93cmmZ+IIS1zcdaDctfdcfKvQ=="
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@kyndryl-design-system/shidoka-foundation/-/shidoka-foundation-2.4.12.tgz",
+      "integrity": "sha512-ru+HQUuFILO9zDYfw0zODTcfRs1OGvMbrJrvmYS/I9YDjsHT0n2PO3320E/uPozohDlFen+W1nBpTbHCM4K54w=="
     },
     "@kyndryl-design-system/shidoka-icons": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "npx husky install"
   },
   "dependencies": {
-    "@kyndryl-design-system/shidoka-foundation": "^2.1.4",
+    "@kyndryl-design-system/shidoka-foundation": "^2.4.12",
     "@kyndryl-design-system/shidoka-icons": "^2.0.0",
     "@sgratzl/chartjs-chart-boxplot": "^4.4.4",
     "chart.js": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "npx husky install"
   },
   "dependencies": {
-    "@kyndryl-design-system/shidoka-foundation": "^2.0.0",
+    "@kyndryl-design-system/shidoka-foundation": "^2.1.4",
     "@kyndryl-design-system/shidoka-icons": "^2.0.0",
     "@sgratzl/chartjs-chart-boxplot": "^4.4.4",
     "chart.js": "^4.4.0",

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -9,7 +9,7 @@ import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/comm
 Chart.register(...registerables, BoxPlotController, BoxAndWiskers);
 
 export const type = 'boxplot';
-export const borderWidth = 2;
+const defaultBorderWidth = 1;
 
 export const options = (ctx) => {
   const horizontal = ctx.options.indexAxis === 'y';
@@ -42,10 +42,8 @@ export const datasetOptions = (ctx, index) => {
   const {
     colorPalette = 'categorical',
     backgroundAlpha = '80',
-    borderWidth = 2,
     outlierStyle = 'circle',
     outlierRadius = 3,
-    outlierBorderWidth = borderWidth,
     lowerBackgroundAlpha = '80',
     upperBackgroundAlpha = '80',
     datasetOptionsOverride = {},
@@ -65,15 +63,15 @@ export const datasetOptions = (ctx, index) => {
   return {
     backgroundColor: color + backgroundAlpha,
     borderColor: mainBoxplotBodyBorder,
-    borderWidth,
+    borderWidth: defaultBorderWidth,
     outlierStyle,
     outlierRadius,
-    outlierBorderWidth,
+    outlierBorderWidth: 1.5,
     outlierBackgroundColor: 'transparent',
     outlierBorderColor: borderColor,
     meanStyle: 'circle',
     meanRadius: 3,
-    meanBorderWidth: 1,
+    meanBorderWidth: defaultBorderWidth,
     meanBackgroundColor: dataPointBackground,
     meanBorderColor: borderColor,
     lowerBackgroundColor: color + lowerBackgroundAlpha,

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -1,24 +1,25 @@
+import { Chart, registerables } from 'chart.js';
+import {
+  BoxPlotController,
+  BoxAndWiskers,
+} from '@sgratzl/chartjs-chart-boxplot';
 import { getComputedColorPalette } from '../colorPalettes';
+import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/common/helpers/color';
+
+Chart.register(...registerables, BoxPlotController, BoxAndWiskers);
 
 export const type = 'boxplot';
+export const borderWidth = 1;
 
 export const options = (ctx) => {
   const horizontal = ctx.options.indexAxis === 'y';
-
   const defaultOptions = {
     scales: {
-      x: {
-        grid: { display: horizontal },
-      },
-      y: {
-        grid: { display: !horizontal },
-      },
+      x: { grid: { display: horizontal } },
+      y: { grid: { display: !horizontal } },
     },
     plugins: {
-      legend: {
-        display: true,
-        position: 'bottom',
-      },
+      legend: { display: true, position: 'bottom' },
       tooltip: {
         enabled: true,
         callbacks: {
@@ -34,50 +35,48 @@ export const options = (ctx) => {
       },
     },
   };
-
-  return {
-    ...defaultOptions,
-    ...(ctx.options || {}),
-  };
+  return { ...defaultOptions, ...(ctx.options || {}) };
 };
 
 export const datasetOptions = (ctx, index) => {
   const {
     colorPalette = 'categorical',
     backgroundAlpha = '80',
-    borderWidth = 1,
+    borderWidth,
     outlierStyle = 'circle',
     outlierRadius = 3,
-    outlierBorderWidth = 1,
+    outlierBorderWidth = borderWidth,
     itemStyle = 'circle',
     itemRadius = 0,
-    itemBorderWidth = 0,
+    itemBorderWidth = borderWidth,
     lowerBackgroundAlpha = '80',
     upperBackgroundAlpha = '80',
     datasetOptionsOverride = {},
   } = ctx.options;
 
   const palette = getComputedColorPalette(colorPalette);
-  const cycles = Math.floor(index / (palette.length - 1));
-  const idx =
-    index > palette.length - 1 ? index - (palette.length - 1) * cycles : index;
+  const idx = index % palette.length;
   const color = palette[idx];
+  const borderColor = getTokenThemeVal('--kd-color-border-level-primary');
+  const meanMedianOutlierBackgroundColor = getTokenThemeVal(
+    '--kd-color-background-container-default'
+  );
 
   return {
     backgroundColor: color + backgroundAlpha,
-    borderColor: color,
+    borderColor: borderColor,
     borderWidth,
     outlierStyle,
     outlierRadius,
     outlierBorderWidth,
-    outlierBackgroundColor: color + backgroundAlpha,
-    outlierBorderColor: color,
-    medianColor: color,
+    outlierBackgroundColor: meanMedianOutlierBackgroundColor,
+    outlierBorderColor: borderColor,
+    medianColor: borderColor,
     meanStyle: 'circle',
     meanRadius: 3,
-    meanBorderWidth: borderWidth,
-    meanBackgroundColor: color + backgroundAlpha,
-    meanBorderColor: color,
+    meanBorderWidth: 1,
+    meanBackgroundColor: meanMedianOutlierBackgroundColor,
+    meanBorderColor: borderColor,
     itemStyle,
     itemRadius,
     itemBorderWidth,

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -41,20 +41,16 @@ export const options = (ctx) => {
 export const datasetOptions = (ctx, index) => {
   const {
     colorPalette = 'categorical',
-    backgroundAlpha = '80',
+    backgroundAlpha = '95',
     outlierStyle = 'circle',
     outlierRadius = 3,
-    lowerBackgroundAlpha = '80',
-    upperBackgroundAlpha = '80',
     datasetOptionsOverride = {},
   } = ctx.options;
 
   const palette = getComputedColorPalette(colorPalette);
   const idx = index % palette.length;
   const color = palette[idx];
-  const borderColor = getTokenThemeVal(
-    '--kd-color-data-viz-neutral-border-primary'
-  );
+  const borderColor = color;
   const dataPointBackground = getTokenThemeVal(
     '--kd-color-data-viz-neutral-background-color'
   );
@@ -73,8 +69,8 @@ export const datasetOptions = (ctx, index) => {
     meanBorderWidth: defaultBorderWidth,
     meanBackgroundColor: dataPointBackground,
     meanBorderColor: borderColor,
-    lowerBackgroundColor: color + lowerBackgroundAlpha,
-    upperBackgroundColor: color + upperBackgroundAlpha,
+    lowerBackgroundColor: color,
+    upperBackgroundColor: color + backgroundAlpha,
     ...datasetOptionsOverride,
   };
 };

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -3,64 +3,72 @@ import {
   BoxPlotController,
   BoxAndWiskers,
 } from '@sgratzl/chartjs-chart-boxplot';
-import { getComputedColorPalette } from '../colorPalettes';
 import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/common/helpers/color';
-import { background } from '@storybook/theming';
+import { getComputedColorPalette } from '../colorPalettes';
 
 Chart.register(...registerables, BoxPlotController, BoxAndWiskers);
 
 export const type = 'boxplot';
 const defaultBorderWidth = 1;
 
-export const options = (ctx) => {
-  const horizontal = ctx.options.indexAxis === 'y';
-  const defaultOptions = {
-    scales: {
-      x: { grid: { display: horizontal } },
-      y: { grid: { display: !horizontal } },
-    },
-    plugins: {
-      legend: { display: true, position: 'bottom' },
-      tooltip: {
-        enabled: true,
-        callbacks: {
-          title: (items) => {
-            const axisLabel = horizontal
-              ? items[0].chart.options.scales.y.title?.text
-              : items[0].chart.options.scales.x.title?.text;
-            return axisLabel
-              ? axisLabel + ': ' + items[0].label
-              : items[0].label;
-          },
+export const options = (ctx) => ({
+  scales: {
+    x: { grid: { display: ctx.options.indexAxis === 'y' } },
+    y: { grid: { display: ctx.options.indexAxis !== 'y' } },
+  },
+  plugins: {
+    legend: { display: true, position: 'bottom' },
+    tooltip: {
+      enabled: true,
+      callbacks: {
+        title: (items) => {
+          const axis = ctx.options.indexAxis === 'y' ? 'y' : 'x';
+          const title = items[0].chart.options.scales[axis].title?.text;
+          return title ? `${title}: ${items[0].label}` : items[0].label;
         },
       },
     },
-  };
-  return { ...defaultOptions, ...(ctx.options || {}) };
-};
+  },
+  ...ctx.options,
+});
 
 export const datasetOptions = (ctx, index) => {
   const {
     colorPalette = 'categorical',
-    backgroundAlpha = '70',
-    upperBackgroundAlpha = '90',
     outlierStyle = 'circle',
     outlierRadius = 3,
     datasetOptionsOverride = {},
   } = ctx.options;
 
   const palette = getComputedColorPalette(colorPalette);
-  const idx = index % palette.length;
-  const color = palette[idx];
-  const borderColor = color;
-  const dataPointBackground = getTokenThemeVal(
+  const hex = palette[index % palette.length];
+  const idxString = String(index + 1).padStart(2, '0');
+
+  const match = colorPalette.match(/^([a-z]+?)(\d{1,2})$/i);
+  const base = match ? match[1] : colorPalette;
+  const num = match ? match[2].padStart(2, '0') : idxString;
+
+  const prefix =
+    colorPalette === 'categorical'
+      ? `sequential-${idxString}`
+      : `${base}-${num}`;
+
+  const borderToken = `--kd-color-data-viz-${prefix}-70`;
+  const lowerToken = `--kd-color-data-viz-${prefix}-40`;
+  const upperToken = `--kd-color-data-viz-${prefix}-20`;
+
+  const borderColor = getTokenThemeVal(borderToken) || hex;
+  const lowerBackgroundColor = getTokenThemeVal(lowerToken) || `${hex}40`;
+  const upperBackgroundColor = getTokenThemeVal(upperToken) || `${hex}20`;
+  const neutralBg = getTokenThemeVal(
     '--kd-color-data-viz-neutral-background-color'
   );
 
   return {
-    backgroundColor: color + backgroundAlpha,
-    borderColor: borderColor,
+    borderColor,
     borderWidth: defaultBorderWidth,
+    backgroundColor: upperBackgroundColor,
+    lowerBackgroundColor,
     outlierStyle,
     outlierRadius,
     outlierBorderWidth: 1.5,
@@ -69,10 +77,8 @@ export const datasetOptions = (ctx, index) => {
     meanStyle: 'circle',
     meanRadius: 3,
     meanBorderWidth: defaultBorderWidth,
-    meanBackgroundColor: dataPointBackground,
+    meanBackgroundColor: neutralBg,
     meanBorderColor: borderColor,
-    lowerBackgroundColor: color + backgroundAlpha,
-    upperBackgroundColor: color + upperBackgroundAlpha,
     ...datasetOptionsOverride,
   };
 };
@@ -82,15 +88,11 @@ export const generateRandomData = (count, min, max, outliers = 0) => {
     Math.floor(Math.random() * (max - min) + min)
   ).sort((a, b) => a - b);
 
-  if (outliers > 0) {
-    for (let i = 0; i < outliers; i++) {
-      if (Math.random() > 0.5) {
-        values.push(max + Math.floor(Math.random() * max * 0.5));
-      } else {
-        values.unshift(
-          Math.max(0, min - Math.floor(Math.random() * min * 0.5))
-        );
-      }
+  for (let i = 0; i < outliers; i++) {
+    if (Math.random() > 0.5) {
+      values.push(max + Math.floor(Math.random() * max * 0.5));
+    } else {
+      values.unshift(Math.max(0, min - Math.floor(Math.random() * min * 0.5)));
     }
   }
 

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -9,7 +9,7 @@ import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/comm
 Chart.register(...registerables, BoxPlotController, BoxAndWiskers);
 
 export const type = 'boxplot';
-export const borderWidth = 1;
+export const borderWidth = 2;
 
 export const options = (ctx) => {
   const horizontal = ctx.options.indexAxis === 'y';
@@ -46,9 +46,6 @@ export const datasetOptions = (ctx, index) => {
     outlierStyle = 'circle',
     outlierRadius = 3,
     outlierBorderWidth = borderWidth,
-    itemStyle = 'circle',
-    itemRadius = 0,
-    itemBorderWidth = borderWidth,
     lowerBackgroundAlpha = '80',
     upperBackgroundAlpha = '80',
     datasetOptionsOverride = {},
@@ -57,29 +54,28 @@ export const datasetOptions = (ctx, index) => {
   const palette = getComputedColorPalette(colorPalette);
   const idx = index % palette.length;
   const color = palette[idx];
+  const mainBoxplotBodyBorder = getTokenThemeVal(
+    '--kd-color-border-level-primary'
+  );
   const borderColor = getTokenThemeVal('--kd-color-border-level-primary');
-  const meanMedianOutlierBackgroundColor = getTokenThemeVal(
+  const dataPointBackground = getTokenThemeVal(
     '--kd-color-background-container-default'
   );
 
   return {
     backgroundColor: color + backgroundAlpha,
-    borderColor: borderColor,
+    borderColor: mainBoxplotBodyBorder,
     borderWidth,
     outlierStyle,
     outlierRadius,
     outlierBorderWidth,
-    outlierBackgroundColor: meanMedianOutlierBackgroundColor,
+    outlierBackgroundColor: 'transparent',
     outlierBorderColor: borderColor,
-    medianColor: borderColor,
     meanStyle: 'circle',
     meanRadius: 3,
     meanBorderWidth: 1,
-    meanBackgroundColor: meanMedianOutlierBackgroundColor,
+    meanBackgroundColor: dataPointBackground,
     meanBorderColor: borderColor,
-    itemStyle,
-    itemRadius,
-    itemBorderWidth,
     lowerBackgroundColor: color + lowerBackgroundAlpha,
     upperBackgroundColor: color + upperBackgroundAlpha,
     ...datasetOptionsOverride,

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -5,6 +5,7 @@ import {
 } from '@sgratzl/chartjs-chart-boxplot';
 import { getComputedColorPalette } from '../colorPalettes';
 import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/common/helpers/color';
+import { background } from '@storybook/theming';
 
 Chart.register(...registerables, BoxPlotController, BoxAndWiskers);
 
@@ -41,7 +42,8 @@ export const options = (ctx) => {
 export const datasetOptions = (ctx, index) => {
   const {
     colorPalette = 'categorical',
-    backgroundAlpha = '95',
+    backgroundAlpha = '70',
+    upperBackgroundAlpha = '90',
     outlierStyle = 'circle',
     outlierRadius = 3,
     datasetOptionsOverride = {},
@@ -69,8 +71,8 @@ export const datasetOptions = (ctx, index) => {
     meanBorderWidth: defaultBorderWidth,
     meanBackgroundColor: dataPointBackground,
     meanBorderColor: borderColor,
-    lowerBackgroundColor: color,
-    upperBackgroundColor: color + backgroundAlpha,
+    lowerBackgroundColor: color + backgroundAlpha,
+    upperBackgroundColor: color + upperBackgroundAlpha,
     ...datasetOptionsOverride,
   };
 };

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -52,17 +52,16 @@ export const datasetOptions = (ctx, index) => {
   const palette = getComputedColorPalette(colorPalette);
   const idx = index % palette.length;
   const color = palette[idx];
-  const mainBoxplotBodyBorder = getTokenThemeVal(
-    '--kd-color-border-level-primary'
+  const borderColor = getTokenThemeVal(
+    '--kd-color-data-viz-neutral-border-primary'
   );
-  const borderColor = getTokenThemeVal('--kd-color-border-level-primary');
   const dataPointBackground = getTokenThemeVal(
-    '--kd-color-background-container-default'
+    '--kd-color-data-viz-neutral-background-color'
   );
 
   return {
     backgroundColor: color + backgroundAlpha,
-    borderColor: mainBoxplotBodyBorder,
+    borderColor: borderColor,
     borderWidth: defaultBorderWidth,
     outlierStyle,
     outlierRadius,

--- a/src/common/config/chartTypes/boxplot.js
+++ b/src/common/config/chartTypes/boxplot.js
@@ -42,7 +42,7 @@ export const datasetOptions = (ctx, index) => {
   const {
     colorPalette = 'categorical',
     backgroundAlpha = '80',
-    borderWidth,
+    borderWidth = 2,
     outlierStyle = 'circle',
     outlierRadius = 3,
     outlierBorderWidth = borderWidth,

--- a/src/common/config/chartTypes/violin.js
+++ b/src/common/config/chartTypes/violin.js
@@ -90,7 +90,7 @@ export const datasetOptions = (ctx, index) => {
   };
 };
 
-export function generateRandomData(count, min, max, outliers = 0) {
+export const generateRandomData = (count, min, max, outliers = 0) => {
   const values = Array.from({ length: count }, () =>
     Math.floor(Math.random() * (max - min) + min)
   ).sort((a, b) => a - b);
@@ -104,4 +104,4 @@ export function generateRandomData(count, min, max, outliers = 0) {
   }
 
   return values;
-}
+};

--- a/src/common/config/chartTypes/violin.js
+++ b/src/common/config/chartTypes/violin.js
@@ -42,12 +42,10 @@ export const options = (ctx) => {
     },
     elements: {
       violin: {
-        borderColor: borderColor,
-        borderWidth,
+        borderWidth: 0,
       },
       boxplot: {
-        borderColor: borderColor,
-        borderWidth,
+        borderWidth: 0,
         backgroundColor: meanMedianOutlierBackgroundColor,
         lowerBackgroundColor: meanMedianOutlierBackgroundColor,
         upperBackgroundColor: meanMedianOutlierBackgroundColor,
@@ -73,26 +71,21 @@ export const datasetOptions = (ctx, index) => {
 
   const palette = getComputedColorPalette(colorPalette);
   const fill = palette[index % palette.length] + backgroundAlpha;
+  const mainBorder = palette[index % palette.length];
 
   return {
     backgroundColor: fill,
-    borderColor: borderColor,
+    borderColor: mainBorder,
     borderWidth,
-    lowerBackgroundColor: meanMedianOutlierBackgroundColor,
-    lowerStyle: 'circle',
-    upperBackgroundColor: meanMedianOutlierBackgroundColor,
     meanStyle: 'circle',
     meanRadius: 4,
     meanBorderWidth: borderWidth,
     meanBorderColor: borderColor,
     meanBackgroundColor: meanMedianOutlierBackgroundColor,
-    medianStyle: 'circle',
-    medianRadius: 6,
-    medianBorderWidth: borderWidth,
-    medianBorderColor: borderColor,
-    medianBackgroundColor: meanMedianOutlierBackgroundColor,
     points: pointCount,
     width: violinWidth,
+    lowerBackgroundColor: meanMedianOutlierBackgroundColor,
+    upperBackgroundColor: meanMedianOutlierBackgroundColor,
     ...datasetOptionsOverride,
   };
 };

--- a/src/common/config/chartTypes/violin.js
+++ b/src/common/config/chartTypes/violin.js
@@ -10,7 +10,7 @@ import {
 Chart.register(BoxPlotController, BoxAndWiskers, ViolinController);
 
 export const type = 'violin';
-export const defaultBorderWidth = 1.5;
+export const defaultBorderWidth = 1;
 const borderColor = getTokenThemeVal('--kd-color-border-level-primary');
 const meanMedianOutlierBackgroundColor = getTokenThemeVal(
   '--kd-color-background-container-default'

--- a/src/common/config/chartTypes/violin.js
+++ b/src/common/config/chartTypes/violin.js
@@ -11,9 +11,11 @@ Chart.register(BoxPlotController, BoxAndWiskers, ViolinController);
 
 export const type = 'violin';
 export const defaultBorderWidth = 1;
-const borderColor = getTokenThemeVal('--kd-color-border-level-primary');
+const borderColor = getTokenThemeVal(
+  '--kd-color-data-viz-neutral-border-primary'
+);
 const meanMedianOutlierBackgroundColor = getTokenThemeVal(
-  '--kd-color-background-container-default'
+  '--kd-color-data-viz-neutral-background-color'
 );
 
 export const options = (ctx) => {
@@ -41,9 +43,6 @@ export const options = (ctx) => {
       },
     },
     elements: {
-      violin: {
-        borderWidth: defaultBorderWidth,
-      },
       boxplot: {
         borderWidth: defaultBorderWidth,
         backgroundColor: meanMedianOutlierBackgroundColor,
@@ -71,11 +70,10 @@ export const datasetOptions = (ctx, index) => {
 
   const palette = getComputedColorPalette(colorPalette);
   const fill = palette[index % palette.length] + backgroundAlpha;
-  const mainBorder = palette[index % palette.length];
 
   return {
     backgroundColor: fill,
-    borderColor: mainBorder,
+    borderColor: borderColor,
     borderWidth: defaultBorderWidth,
     meanStyle: 'circle',
     meanRadius: 4,

--- a/src/common/config/chartTypes/violin.js
+++ b/src/common/config/chartTypes/violin.js
@@ -1,24 +1,31 @@
+import Chart from 'chart.js/auto';
 import { getComputedColorPalette } from '../colorPalettes';
+import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/common/helpers/color';
+import {
+  BoxPlotController,
+  BoxAndWiskers,
+  ViolinController,
+} from '@sgratzl/chartjs-chart-boxplot';
+
+Chart.register(BoxPlotController, BoxAndWiskers, ViolinController);
 
 export const type = 'violin';
+export const borderWidth = 1;
+const borderColor = getTokenThemeVal('--kd-color-border-level-primary');
+const meanMedianOutlierBackgroundColor = getTokenThemeVal(
+  '--kd-color-background-container-default'
+);
 
 export const options = (ctx) => {
-  const horizontal = ctx.options.indexAxis === 'y';
+  const horizontal = ctx.options?.indexAxis === 'y';
 
-  const defaultOptions = {
+  return {
     scales: {
-      x: {
-        grid: { display: horizontal },
-      },
-      y: {
-        grid: { display: !horizontal },
-      },
+      x: { grid: { display: horizontal } },
+      y: { grid: { display: !horizontal } },
     },
     plugins: {
-      legend: {
-        display: true,
-        position: 'bottom',
-      },
+      legend: { display: true, position: 'bottom' },
       tooltip: {
         enabled: true,
         callbacks: {
@@ -27,16 +34,31 @@ export const options = (ctx) => {
               ? items[0].chart.options.scales.y.title?.text
               : items[0].chart.options.scales.x.title?.text;
             return axisLabel
-              ? axisLabel + ': ' + items[0].label
+              ? `${axisLabel}: ${items[0].label}`
               : items[0].label;
           },
         },
       },
     },
-  };
-  return {
-    ...defaultOptions,
-    ...(ctx.options || {}),
+    elements: {
+      violin: {
+        borderColor: borderColor,
+        borderWidth,
+      },
+      boxplot: {
+        borderColor: borderColor,
+        borderWidth,
+        backgroundColor: meanMedianOutlierBackgroundColor,
+        lowerBackgroundColor: meanMedianOutlierBackgroundColor,
+        upperBackgroundColor: meanMedianOutlierBackgroundColor,
+        medianStyle: 'circle',
+        medianRadius: 6,
+        medianBorderWidth: borderWidth,
+        medianBorderColor: borderColor,
+        medianBackgroundColor: meanMedianOutlierBackgroundColor,
+      },
+    },
+    ...ctx.options,
   };
 };
 
@@ -44,61 +66,49 @@ export const datasetOptions = (ctx, index) => {
   const {
     colorPalette = 'categorical',
     backgroundAlpha = '95',
-    borderWidth = 1,
-    outlierStyle = 'circle',
-    outlierRadius = 3,
-    outlierBorderWidth = 1,
-    meanStyle = 'circle',
-    meanRadius = 3,
-    meanBorderWidth = 1,
     pointCount = 100,
     violinWidth = 0.8,
     datasetOptionsOverride = {},
-  } = ctx.options;
+  } = ctx.options || {};
 
   const palette = getComputedColorPalette(colorPalette);
-  const cycles = Math.floor(index / (palette.length - 1));
-  const idx =
-    index > palette.length - 1 ? index - (palette.length - 1) * cycles : index;
-  const color = palette[idx];
+  const fill = palette[index % palette.length] + backgroundAlpha;
 
   return {
-    backgroundColor: color + backgroundAlpha,
-    borderColor: color,
+    backgroundColor: fill,
+    borderColor: borderColor,
     borderWidth,
-    outlierStyle,
-    outlierRadius,
-    outlierBorderWidth,
-    outlierBackgroundColor: color + backgroundAlpha,
-    outlierBorderColor: color,
-    medianColor: color,
-    meanStyle,
-    meanRadius,
-    meanBorderWidth,
-    meanBackgroundColor: color + backgroundAlpha,
-    meanBorderColor: color,
+    lowerBackgroundColor: meanMedianOutlierBackgroundColor,
+    lowerStyle: 'circle',
+    upperBackgroundColor: meanMedianOutlierBackgroundColor,
+    meanStyle: 'circle',
+    meanRadius: 4,
+    meanBorderWidth: borderWidth,
+    meanBorderColor: borderColor,
+    meanBackgroundColor: meanMedianOutlierBackgroundColor,
+    medianStyle: 'circle',
+    medianRadius: 6,
+    medianBorderWidth: borderWidth,
+    medianBorderColor: borderColor,
+    medianBackgroundColor: meanMedianOutlierBackgroundColor,
     points: pointCount,
     width: violinWidth,
     ...datasetOptionsOverride,
   };
 };
 
-export const generateRandomData = (count, min, max, outliers = 0) => {
+export function generateRandomData(count, min, max, outliers = 0) {
   const values = Array.from({ length: count }, () =>
     Math.floor(Math.random() * (max - min) + min)
   ).sort((a, b) => a - b);
 
-  if (outliers > 0) {
-    for (let i = 0; i < outliers; i++) {
-      if (Math.random() > 0.5) {
-        values.push(max + Math.floor(Math.random() * max * 0.5));
-      } else {
-        values.unshift(
-          Math.max(0, min - Math.floor(Math.random() * min * 0.5))
-        );
-      }
+  for (let i = 0; i < outliers; i++) {
+    if (Math.random() > 0.5) {
+      values.push(max + Math.floor(Math.random() * max * 0.5));
+    } else {
+      values.unshift(Math.max(0, min - Math.floor(Math.random() * min * 0.5)));
     }
   }
 
   return values;
-};
+}

--- a/src/common/config/chartTypes/violin.js
+++ b/src/common/config/chartTypes/violin.js
@@ -10,7 +10,7 @@ import {
 Chart.register(BoxPlotController, BoxAndWiskers, ViolinController);
 
 export const type = 'violin';
-export const borderWidth = 1;
+export const defaultBorderWidth = 1.5;
 const borderColor = getTokenThemeVal('--kd-color-border-level-primary');
 const meanMedianOutlierBackgroundColor = getTokenThemeVal(
   '--kd-color-background-container-default'
@@ -42,16 +42,16 @@ export const options = (ctx) => {
     },
     elements: {
       violin: {
-        borderWidth: 0,
+        borderWidth: defaultBorderWidth,
       },
       boxplot: {
-        borderWidth: 0,
+        borderWidth: defaultBorderWidth,
         backgroundColor: meanMedianOutlierBackgroundColor,
         lowerBackgroundColor: meanMedianOutlierBackgroundColor,
         upperBackgroundColor: meanMedianOutlierBackgroundColor,
         medianStyle: 'circle',
         medianRadius: 6,
-        medianBorderWidth: borderWidth,
+        medianBorderWidth: defaultBorderWidth,
         medianBorderColor: borderColor,
         medianBackgroundColor: meanMedianOutlierBackgroundColor,
       },
@@ -76,10 +76,10 @@ export const datasetOptions = (ctx, index) => {
   return {
     backgroundColor: fill,
     borderColor: mainBorder,
-    borderWidth,
+    borderWidth: defaultBorderWidth,
     meanStyle: 'circle',
     meanRadius: 4,
-    meanBorderWidth: borderWidth,
+    meanBorderWidth: defaultBorderWidth,
     meanBorderColor: borderColor,
     meanBackgroundColor: meanMedianOutlierBackgroundColor,
     points: pointCount,

--- a/src/stories/Boxplot.stories.js
+++ b/src/stories/Boxplot.stories.js
@@ -61,6 +61,57 @@ const doubleDataset = [
   },
 ];
 
+const quadrupleDataset = [
+  {
+    label: 'Dataset 1',
+    data: [
+      generateRandomData(30, 10, 100, 2),
+      generateRandomData(30, 20, 80, 1),
+      generateRandomData(30, 30, 120, 3),
+      generateRandomData(30, 40, 90, 2),
+      generateRandomData(30, 20, 70, 1),
+      generateRandomData(30, 10, 60, 2),
+      generateRandomData(30, 30, 80, 1),
+    ],
+  },
+  {
+    label: 'Dataset 2',
+    data: [
+      generateRandomData(30, 20, 120, 1),
+      generateRandomData(30, 10, 100, 2),
+      generateRandomData(30, 20, 90, 1),
+      generateRandomData(30, 30, 110, 3),
+      generateRandomData(30, 40, 80, 2),
+      generateRandomData(30, 20, 90, 1),
+      generateRandomData(30, 30, 70, 0),
+    ],
+  },
+  {
+    label: 'Dataset 3',
+    data: [
+      generateRandomData(30, 20, 120, 1),
+      generateRandomData(30, 10, 100, 2),
+      generateRandomData(30, 20, 90, 1),
+      generateRandomData(30, 30, 110, 3),
+      generateRandomData(30, 40, 80, 2),
+      generateRandomData(30, 20, 90, 1),
+      generateRandomData(30, 30, 70, 0),
+    ],
+  },
+  {
+    label: 'Dataset 4',
+    data: [
+      generateRandomData(30, 20, 120, 1),
+      generateRandomData(30, 10, 100, 2),
+      generateRandomData(30, 20, 90, 1),
+      generateRandomData(30, 30, 110, 3),
+      generateRandomData(30, 40, 80, 2),
+      generateRandomData(30, 20, 90, 1),
+      generateRandomData(30, 30, 70, 0),
+    ],
+  },
+];
+
 const baseArgs = {
   chartTitle: 'Boxplot Example',
   description: 'Boxplot chart with two datasets',
@@ -88,6 +139,46 @@ const baseArgs = {
 
 export const Default = {
   args: baseArgs,
+  render: (args) => {
+    return html`
+      <kd-chart
+        type="boxplot"
+        .chartTitle=${args.chartTitle}
+        .description=${args.description}
+        .labels=${args.labels}
+        .datasets=${args.datasets}
+        .options=${{
+          colorPalette: args.colorPalette,
+          plugins: {
+            legend: { display: true },
+            tooltip: { enabled: true },
+          },
+          scales: args.options?.scales || {
+            x: {
+              title: { display: true, text: 'Categories' },
+            },
+            y: {
+              title: { display: true, text: 'Values' },
+            },
+          },
+        }}
+        ?hideDescription=${args.hideDescription}
+        ?hideCaptions=${args.hideCaptions}
+        ?hideHeader=${args.hideHeader}
+        ?hideControls=${args.hideControls}
+        ?noBorder=${args.noBorder}
+        .width=${args.width}
+        .height=${args.height}
+      ></kd-chart>
+    `;
+  },
+};
+
+export const FourDatasetExample = {
+  args: {
+    ...baseArgs,
+    datasets: quadrupleDataset,
+  },
   render: (args) => {
     return html`
       <kd-chart


### PR DESCRIPTION
## Summary

Implements some slight style changes to boxplot and violin plot charts.

1. Cleans up unused key-value pairs in the chart configs for Boxplot and Violin Plot
2. Gives the outlier and mean (circular shaped nodes) a white background and gray border so that it contrasts more with the main body of the boxplot and violin plot
3. border and wisker/whisker in boxplot made gray

_Notes:_ 
_- Median (diamond/rotated square shaped item) styles are not modifiable, only outlier and mean._
_- border width for boxplot and violin plot items are set to 1 -- numerically matches figma, but does not visually match._

## ADO Story or GitHub Issue Link

Link here (if applicable).

## Figma Link

[Figma](https://www.figma.com/design/VC8A7QxPdskgsXcfw9czLO/2.2-Oreo?node-id=7169-46332&m=dev)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [x] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

#### Boxplot Example
<img width="735" alt="Screenshot 2025-05-19 at 10 52 47 AM" src="https://github.com/user-attachments/assets/6d1049a3-47a4-469f-8593-c26608e3e06a" />

#### Violin Plot Example
<img width="887" alt="Screenshot 2025-05-15 at 1 46 58 PM" src="https://github.com/user-attachments/assets/3c522612-99bf-4f5e-aa72-f14f7215bc9e" />