### PR TITLE
fix(bug-48): extra long description overflow issue

### DIFF
--- a/src/components/chart/chart.scss
+++ b/src/components/chart/chart.scss
@@ -161,6 +161,18 @@ table {
   }
 }
 
+#titleDesc {
+  flex: 1 1 auto;
+  max-width: 126%;
+  min-width: 0;
+  overflow-wrap: break-word;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 .title {
   font-weight: 500;
   @include typography.type-ui-02;
@@ -169,6 +181,8 @@ table {
 .description {
   color: var(--kd-color-text-level-secondary);
   @include typography.type-ui-03;
+  // to prevent extra long description from creeping up against chart controls:
+  padding-right: 8px;
 }
 
 .controls {

--- a/src/components/chart/chart.scss
+++ b/src/components/chart/chart.scss
@@ -151,7 +151,7 @@ table {
 
 .header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 24px;
 
   .widget & {
@@ -162,19 +162,19 @@ table {
 }
 
 #titleDesc {
+  display: flex;
+  flex-direction: column;
   flex: 1 1 auto;
-  max-width: 126%;
   min-width: 0;
-  overflow-wrap: break-word;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
+  align-self: flex-start;
 }
 
 .title {
   font-weight: 500;
+  flex: 0 0 auto;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   @include typography.type-ui-02;
 }
 
@@ -182,11 +182,20 @@ table {
   color: var(--kd-color-text-level-secondary);
   // to prevent extra long description from creeping up against chart controls:
   padding-right: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow-wrap: break-word;
   @include typography.type-ui-03;
 }
 
 .controls {
   display: flex;
+  margin-top: 4px;
   gap: 8px;
   align-items: center;
   margin-left: auto;

--- a/src/components/chart/chart.scss
+++ b/src/components/chart/chart.scss
@@ -175,6 +175,8 @@ table {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  // to prevent extra long title from creeping up against chart controls:
+  padding-right: 8px;
   @include typography.type-ui-02;
 }
 
@@ -195,7 +197,6 @@ table {
 
 .controls {
   display: flex;
-  margin-top: 4px;
   gap: 8px;
   align-items: center;
   margin-left: auto;

--- a/src/components/chart/chart.scss
+++ b/src/components/chart/chart.scss
@@ -180,9 +180,9 @@ table {
 
 .description {
   color: var(--kd-color-text-level-secondary);
-  @include typography.type-ui-03;
   // to prevent extra long description from creeping up against chart controls:
   padding-right: 8px;
+  @include typography.type-ui-03;
 }
 
 .controls {


### PR DESCRIPTION
## Summary

Simple style fix to to constrain extra long descriptions and their effect on shifting chart header elements.

## ADO Story or GitHub Issue Link

fixes #48 
[AB#2333475](https://dev.azure.com/Kyndryl/f7f7ab25-06ec-43dc-902d-dee2e157cebd/_workitems/edit/2333475)

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Screenshots

#### Before
<img width="346" alt="1cf369bb-1412-4e7d-8e58-417029366bc5" src="https://github.com/user-attachments/assets/2cf844e0-b420-4c11-8a65-a1a7fc0e5ef7" />

#### After (small vs larger widget/chart size)
<img width="329" alt="Screenshot 2025-06-18 at 7 51 34 AM" src="https://github.com/user-attachments/assets/22578fbf-6de2-4138-8347-f866859b2bba" />

<img width="791" alt="Screenshot 2025-06-18 at 7 58 41 AM" src="https://github.com/user-attachments/assets/aba070ef-855c-4736-af3d-db6b53a1f7af" />

