### PR TITLE
fix(chart): disabled png jpg download option on table view

### DIFF
--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -398,20 +398,24 @@ export class KDChart extends LitElement {
                                         </button>
                                       `
                                     : null}
-                                  <button
-                                    tabindex="0"
-                                    @click=${(e: Event) =>
-                                      this.handleDownloadImage(e, false)}
-                                  >
-                                    ${this.customLabels.downloadPng}
-                                  </button>
-                                  <button
-                                    tabindex="0"
-                                    @click=${(e: Event) =>
-                                      this.handleDownloadImage(e, true)}
-                                  >
-                                    ${this.customLabels.downloadJpg}
-                                  </button>
+                                  ${!this.tableView
+                                    ? html`
+                                        <button
+                                          tabindex="0"
+                                          @click=${(e: Event) =>
+                                            this.handleDownloadImage(e, false)}
+                                        >
+                                          ${this.customLabels.downloadPng}
+                                        </button>
+                                        <button
+                                          tabindex="0"
+                                          @click=${(e: Event) =>
+                                            this.handleDownloadImage(e, true)}
+                                        >
+                                          ${this.customLabels.downloadJpg}
+                                        </button>
+                                      `
+                                    : null}
                                 </div>
                               </div>
                             `


### PR DESCRIPTION
## Summary

Brief summary describing the changes here.

## ADO Story or GitHub Issue Link

[AB#2732705](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2732705)

resolves https://github.com/kyndryl-design-system/shidoka-charts/issues/72

## Notes

- Detailed change notes
- can go here

## To Do

- Anything else
- left to do

## Checklist

- [X] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

(if any)
