### PR TITLE
fix(fanchart): cleanup to respect themes change on fly

### DIFF
--- a/src/common/plugins/pointColumnHighlight.js
+++ b/src/common/plugins/pointColumnHighlight.js
@@ -10,7 +10,7 @@ import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/comm
  *     backgroundColor: '--kd-color-background-container-soft',
  *   }
  * }
- * Note: This plugin works best with x-axis offset.
+ * Note: This plugin works best with x-axis offset enabled.
  */
 
 const resolveColor = (color) =>

--- a/src/common/plugins/pointColumnHighlight.js
+++ b/src/common/plugins/pointColumnHighlight.js
@@ -53,7 +53,8 @@ export default {
 
     ctx.save();
     ctx.fillStyle = resolveColor(
-      options?.backgroundColor || 'rgba(0, 0, 0, 0.06)'
+      options?.backgroundColor ||
+        getTokenThemeVal('--kd-color-background-container-subtle')
     );
     ctx.fillRect(
       Math.min(xMin, xMax),

--- a/src/stories/Line.stories.js
+++ b/src/stories/Line.stories.js
@@ -614,8 +614,9 @@ export const FanChart = {
     highlightStartIndex: 0,
   },
   argTypes: {
+    colorPalette: hideUnusedControls,
     highlightStartIndex: {
-      name: 'Column highlight start (x index)',
+      name: 'pointColumnHighlightIndex (x index)',
       control: {
         type: 'number',
         min: 0,

--- a/src/stories/Line.stories.js
+++ b/src/stories/Line.stories.js
@@ -476,16 +476,14 @@ const colorToRgba = (color, alpha) => {
 };
 
 const getConfidenceBandDatasets = (colorPalette = 'categorical') => {
-  const colors = getComputedColorPalette(colorPalette);
-  const lineColor = colors[0];
-  const forecastBandColor = getComputedColorPalette('divergent01')[14];
+  const forecastBandToken = () => getComputedColorPalette('divergent01')[14];
 
   const createBandDataset = (label, data, order, opacity) => ({
     label,
     data,
     fill: fanChartMedianDatasetIndex,
     borderColor: 'transparent',
-    backgroundColor: colorToRgba(forecastBandColor, opacity),
+    backgroundColor: () => colorToRgba(forecastBandToken(), opacity),
     borderWidth: 0,
     pointRadius: 0,
     pointHoverRadius: 0,
@@ -497,7 +495,8 @@ const getConfidenceBandDatasets = (colorPalette = 'categorical') => {
       label: 'Net Income',
       data: fanChartMedian,
       fill: false,
-      borderColor: lineColor,
+      borderColor: () => getComputedColorPalette(colorPalette)[0],
+      backgroundColor: () => getComputedColorPalette(colorPalette)[0],
       borderWidth: 2,
       pointRadius: 0,
       pointHoverRadius: 5,
@@ -542,74 +541,89 @@ const getConfidenceBandDatasets = (colorPalette = 'categorical') => {
   ];
 };
 
+const getFanChartOptions = (highlightStartIndex = 0) => ({
+  interaction: {
+    mode: 'index',
+    intersect: false,
+  },
+  scales: {
+    x: {
+      offset: true,
+      min: 1,
+      max: 12,
+      title: {
+        text: 'Quarter',
+      },
+    },
+    y: {
+      position: 'right',
+      title: {
+        text: 'Count',
+      },
+      min: 0,
+      max: 40,
+      ticks: {
+        stepSize: 10,
+        callback: (value) => `${value}M`,
+      },
+    },
+  },
+  plugins: {
+    legend: {
+      display: false,
+    },
+    annotation: {
+      annotations: {
+        forecastRegion: {
+          type: 'box',
+          xMin: fanChartForecastStartIndex,
+          xMax: fanChartLabels.length - 0.5,
+          backgroundColor: () =>
+            getComputedColorPalette('divergent01')[14] + '10',
+          borderWidth: 0,
+        },
+        forecastDivider: {
+          type: 'line',
+          xMin: fanChartForecastStartIndex,
+          xMax: fanChartForecastStartIndex,
+          borderColor: () =>
+            getTokenThemeVal('--kd-color-border-variants-focus'),
+          borderDash: [10, 10],
+          borderWidth: 1,
+        },
+      },
+    },
+    tooltip: {
+      filter: (tooltipItem) => tooltipItem.dataset.label === 'Net Income',
+      callbacks: {
+        label: (context) => `Net Income: ${context.parsed.y}M`,
+      },
+    },
+    pointColumnHighlight: {
+      datasetIndex: highlightStartIndex,
+      backgroundColor: '--kd-color-background-container-subtle',
+    },
+  },
+});
+
 export const FanChart = {
+  // see the config here https://github.com/kyndryl-design-system/shidoka-charts/blob/main/src/stories/Line.stories.js
   tags: ['new'],
   args: {
     labels: fanChartLabels,
-    options: {
-      interaction: {
-        mode: 'index',
-        intersect: false,
+    highlightStartIndex: 0,
+  },
+  argTypes: {
+    highlightStartIndex: {
+      name: 'Column highlight start (x index)',
+      control: {
+        type: 'number',
+        min: 0,
+        max: fanChartLabels.length - 1,
+        step: 1,
       },
-      scales: {
-        x: {
-          offset: true,
-          min: 1,
-          max: 12,
-          title: {
-            text: 'Quarter',
-          },
-        },
-        y: {
-          position: 'right',
-          title: {
-            text: 'Count',
-          },
-          min: 0,
-          max: 40,
-          ticks: {
-            stepSize: 10,
-            callback: (value) => `${value}M`,
-          },
-        },
-      },
-      plugins: {
-        legend: {
-          display: false,
-        },
-        annotation: {
-          annotations: {
-            forecastRegion: {
-              type: 'box',
-              xMin: fanChartForecastStartIndex,
-              xMax: fanChartLabels.length - 0.5,
-              backgroundColor:
-                getComputedColorPalette('divergent01')[14] + '10',
-              borderWidth: 0,
-            },
-            forecastDivider: {
-              type: 'line',
-              xMin: fanChartForecastStartIndex,
-              xMax: fanChartForecastStartIndex,
-              borderColor: getTokenThemeVal('--kd-color-border-variants-focus'),
-              borderDash: [10, 10],
-              borderWidth: 1,
-            },
-          },
-        },
-        tooltip: {
-          filter: (tooltipItem) => tooltipItem.dataset.label === 'Net Income',
-          callbacks: {
-            label: (context) => `Net Income: ${context.parsed.y}M`,
-          },
-        },
-        // custom plugin to highlight the datapoint when hovering over the chart
-        // Optional: specify datasetIndex to highlight; omit to use the first active element
-        pointColumnHighlight: {
-          datasetIndex: 0,
-          backgroundColor: '--kd-color-background-container-subtle',
-        },
-      },
+      description:
+        'First x-axis index where the hover column highlight is shown.',
     },
   },
   render: (args) => {
@@ -619,8 +633,29 @@ export const FanChart = {
         .chartTitle=${`Forecast Line chart - Confidence Bands`}
         .labels=${args.labels}
         .datasets=${getConfidenceBandDatasets('categorical')}
-        .options=${{ ...args.options }}
+        .options=${getFanChartOptions(args.highlightStartIndex)}
       ></kd-chart>
+
+      <br />
+      <br />
+      <i
+        >Note: This chart uses custom plugin called
+        <a
+          href="https://github.com/kyndryl-design-system/shidoka-charts/blob/main/src/common/plugins/pointColumnHighlight.js"
+          target="_blank"
+          rel="noopener noreferrer"
+          >pointColumnHighlight</a
+        >
+        to highlight dataset points on hover.</i
+      >
+      <br />
+      Also, See Fan chart config here:
+      <a
+        href="https://github.com/kyndryl-design-system/shidoka-charts/blob/main/src/stories/Line.stories.js"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Line.stories.js</a
+      >
     `;
   },
 };

--- a/src/stories/Line.stories.js
+++ b/src/stories/Line.stories.js
@@ -2,7 +2,6 @@ import { html } from 'lit';
 import { getTokenThemeVal } from '@kyndryl-design-system/shidoka-foundation/common/helpers/color';
 import '../components/chart';
 import argTypes, { hideUnusedControls } from '../common/config/chartArgTypes';
-import { getComputedColorPalette } from '../common/config/colorPalettes';
 
 export default {
   title: 'Charts/Line',
@@ -475,8 +474,11 @@ const colorToRgba = (color, alpha) => {
   return color;
 };
 
-const getConfidenceBandDatasets = (colorPalette = 'categorical') => {
-  const forecastBandToken = () => getComputedColorPalette('divergent01')[14];
+const getConfidenceBandDatasets = () => {
+  const forecastBandToken = () =>
+    getTokenThemeVal('--kd-color-data-viz-divergent-01-positive-40');
+
+  console.log(forecastBandToken());
 
   const createBandDataset = (label, data, order, opacity) => ({
     label,
@@ -495,8 +497,10 @@ const getConfidenceBandDatasets = (colorPalette = 'categorical') => {
       label: 'Net Income',
       data: fanChartMedian,
       fill: false,
-      borderColor: () => getComputedColorPalette(colorPalette)[0],
-      backgroundColor: () => getComputedColorPalette(colorPalette)[0],
+      borderColor: getTokenThemeVal('--kd-color-data-viz-categorical-01-01'),
+      backgroundColor: getTokenThemeVal(
+        '--kd-color-data-viz-categorical-01-01'
+      ),
       borderWidth: 2,
       pointRadius: 0,
       pointHoverRadius: 5,
@@ -578,16 +582,16 @@ const getFanChartOptions = (highlightStartIndex = 0) => ({
           type: 'box',
           xMin: fanChartForecastStartIndex,
           xMax: fanChartLabels.length - 0.5,
-          backgroundColor: () =>
-            getComputedColorPalette('divergent01')[14] + '10',
+          backgroundColor:
+            getTokenThemeVal('--kd-color-data-viz-divergent-01-positive-40') +
+            '10',
           borderWidth: 0,
         },
         forecastDivider: {
           type: 'line',
           xMin: fanChartForecastStartIndex,
           xMax: fanChartForecastStartIndex,
-          borderColor: () =>
-            getTokenThemeVal('--kd-color-border-variants-focus'),
+          borderColor: getTokenThemeVal('--kd-color-border-variants-focus'),
           borderDash: [10, 10],
           borderWidth: 1,
         },
@@ -633,7 +637,7 @@ export const FanChart = {
         type="line"
         .chartTitle=${`Forecast Line chart - Confidence Bands`}
         .labels=${args.labels}
-        .datasets=${getConfidenceBandDatasets('categorical')}
+        .datasets=${getConfidenceBandDatasets()}
         .options=${getFanChartOptions(args.highlightStartIndex)}
       ></kd-chart>
 


### PR DESCRIPTION
## Summary

Storybook strips non-serializable functions from args when controls update. Annotation colors are functions in args.options, so they're lost when datasetIndex changes. So, Moving theme-dependent plugin config into render() and exposing highlightStartIndex as a serializable arg through controls. This fix also respect theme change.

## ADO Story or GitHub Issue Link

## Notes

- Detailed change notes
- can go here

## To Do

- Anything else
- left to do

## Checklist

- [x] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.
- [ ] Added any new component exports to the src/index.ts file


